### PR TITLE
Existing tests reference spec conformance item

### DIFF
--- a/testing/SPEC-CONFORMANCE.md
+++ b/testing/SPEC-CONFORMANCE.md
@@ -66,7 +66,7 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 |R57|3.2.2.4|`div` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
 |R58|3.2.2.4|`div` `end` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. | |
 |R59|3.2.2.4|`div` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. | |
-|R60|3.2.2.5|`p` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
+|R60|3.2.2.5|`p` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
 |R61|3.2.2.5|`p` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R62|3.2.2.5|`p` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R63|3.2.2.5|`p` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |

--- a/testing/bdd/features/validation/sequence_id_num.feature
+++ b/testing/bdd/features/validation/sequence_id_num.feature
@@ -1,29 +1,31 @@
 Feature: Sequence ID and Sequence Number
-    Both are mandatory parameters and the sequence number has to be a number (no letters)
+  Both are mandatory parameters and the sequence number has to be a number (no letters)
 
-    Scenario: Invalid Sequence head attributes
-        Given an xml file <xml_file>
-        And it has sequence identifier <seq_id>
-        And it has sequence number <seq_n>
-        Then document is invalid
+  #SPEC_CONFORMANCE : R6 R7 R34 R35 R36
+  Scenario: Invalid Sequence head attributes
+    Given an xml file <xml_file>
+    And it has sequence identifier <seq_id>
+    And it has sequence number <seq_n>
+    Then document is invalid
 
-        Examples:
-        | xml_file            | seq_id   | seq_n |
-        | sequence_id_num.xml |          | 5     |
-        | sequence_id_num.xml | testSeq1 | a     |
-        | sequence_id_num.xml | testSeq1 | -5    |
-        | sequence_id_num.xml | testSeq1 |       |
-        | sequence_id_num.xml |          |       |
+    Examples:
+      | xml_file            | seq_id   | seq_n |
+      | sequence_id_num.xml |          | 5     |
+      | sequence_id_num.xml | testSeq1 | a     |
+      | sequence_id_num.xml | testSeq1 | -5    |
+      | sequence_id_num.xml | testSeq1 |       |
+      | sequence_id_num.xml |          |       |
 
-    Scenario: Valid Sequence head attributes
-        Given an xml file <xml_file>
-        And it has sequence identifier <seq_id>
-        And it has sequence number <seq_n>
-        Then document is valid
+  #SPEC_CONFORMANCE : R6 R7 R34 R35 R36
+  Scenario: Valid Sequence head attributes
+    Given an xml file <xml_file>
+    And it has sequence identifier <seq_id>
+    And it has sequence number <seq_n>
+    Then document is valid
 
-        Examples:
-        | xml_file            | seq_id   | seq_n     |
-        | sequence_id_num.xml | testSeq1 | 5         |
-        | sequence_id_num.xml | a        | 10        |
-        | sequence_id_num.xml | testSeq1 | 999999999 |
+    Examples:
+      | xml_file            | seq_id   | seq_n     |
+      | sequence_id_num.xml | testSeq1 | 5         |
+      | sequence_id_num.xml | a        | 10        |
+      | sequence_id_num.xml | testSeq1 | 999999999 |
 

--- a/testing/bdd/features/validation/sequence_id_num.feature
+++ b/testing/bdd/features/validation/sequence_id_num.feature
@@ -1,7 +1,7 @@
 Feature: Sequence ID and Sequence Number
   Both are mandatory parameters and the sequence number has to be a number (no letters)
 
-  #SPEC_CONFORMANCE : R6 R7 R34 R35 R36
+  # SPEC_CONFORMANCE : R6 R7 R34 R35 R36
   Scenario: Invalid Sequence head attributes
     Given an xml file <xml_file>
     And it has sequence identifier <seq_id>
@@ -16,7 +16,7 @@ Feature: Sequence ID and Sequence Number
       | sequence_id_num.xml | testSeq1 |       |
       | sequence_id_num.xml |          |       |
 
-  #SPEC_CONFORMANCE : R6 R7 R34 R35 R36
+  # SPEC_CONFORMANCE : R6 R7 R34 R35 R36
   Scenario: Valid Sequence head attributes
     Given an xml file <xml_file>
     And it has sequence identifier <seq_id>

--- a/testing/bdd/features/validation/sequence_id_num.feature
+++ b/testing/bdd/features/validation/sequence_id_num.feature
@@ -1,7 +1,7 @@
 Feature: Sequence ID and Sequence Number
   Both are mandatory parameters and the sequence number has to be a number (no letters)
 
-  # SPEC_CONFORMANCE : R6 R7 R34 R35 R36
+  # SPEC-CONFORMANCE: R6 R7 R34 R35 R36
   Scenario: Invalid Sequence head attributes
     Given an xml file <xml_file>
     And it has sequence identifier <seq_id>
@@ -16,7 +16,7 @@ Feature: Sequence ID and Sequence Number
       | sequence_id_num.xml | testSeq1 |       |
       | sequence_id_num.xml |          |       |
 
-  # SPEC_CONFORMANCE : R6 R7 R34 R35 R36
+  # SPEC-CONFORMANCE: R6 R7 R34 R35 R36
   Scenario: Valid Sequence head attributes
     Given an xml file <xml_file>
     And it has sequence identifier <seq_id>

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -1,6 +1,6 @@
 Feature: ttp:timeBase-related attribute constraints
 
-  # SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
+  # SPEC-CONFORMANCE: R46 R47 R49 R50 R52 R53
   Scenario: Valid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -23,7 +23,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
   # These tests are not all passing because the missing semantic validation piece
-  # SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
+  # SPEC-CONFORMANCE: R46 R47 R49 R50 R52 R53
   Scenario: Invalid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -46,7 +46,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
 
-  # SPEC-CONFORMANCE : R61 R62 R64 R65
+  # SPEC-CONFORMANCE: R61 R62 R64 R65
   Scenario: Valid times according to timeBase in p
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -63,7 +63,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
 
-  # SPEC-CONFORMANCE : R61 R62 R64 R65
+  # SPEC-CONFORMANCE: R61 R62 R64 R65
   @skip
   Scenario: Invalid times according to timeBase in p
     Given an xml file <xml_file>

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -1,6 +1,6 @@
 Feature: ttp:timeBase-related attribute constraints
 
-  #SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
+  # SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
   Scenario: Valid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -23,7 +23,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
   # These tests are not all passing because the missing semantic validation piece
-  #SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
+  # SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
   Scenario: Invalid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -1,4 +1,6 @@
 Feature: ttp:timeBase-related attribute constraints
+
+  #SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
   Scenario: Valid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -20,7 +22,8 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | media     |             |                | 2225:59:60.9 |
 
 
-    # These tests are not all passing because the missing semantic validation piece
+  # These tests are not all passing because the missing semantic validation piece
+  #SPEC-CONFORMANCE : R46 R47 R49 R50 R52 R53
   Scenario: Invalid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -43,7 +46,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
 
-
+  # SPEC-CONFORMANCE : R61 R62 R64 R65
   Scenario: Valid times according to timeBase in p
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -60,6 +63,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
 
+  # SPEC-CONFORMANCE : R61 R62 R64 R65
   @skip
   Scenario: Invalid times according to timeBase in p
     Given an xml file <xml_file>


### PR DESCRIPTION
Tests simply reference the R numbers they test from the `SPEC_CONFORMANCE.md` document.