### PR TITLE
Enhance time base timeformat tests

### DIFF
--- a/testing/SPEC-CONFORMANCE.md
+++ b/testing/SPEC-CONFORMANCE.md
@@ -51,10 +51,10 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 |R42|3.2.2.2.1| `ebuttm:trace` `action` attribute Cardinality 1..1 | |
 |R43|3.2.2.2.1| `ebuttm:trace` `generatedBy` attribute Cardinality 1..1 | |
 |R44|3.2.2.3| A document that contains a `tt:body` element with no content shall be treated as being active as defined by the semantics described in § 2.3.1, and shall cause no content to be presented while it is active.| |
-|R45|3.2.2.3|`body` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
+|R45|3.2.2.3|`body` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
 |R46|3.2.2.3|`body` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
 |R47|3.2.2.3|`body` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
-|R48|3.2.2.3|`body` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
+|R48|3.2.2.3|`body` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
 |R49|3.2.2.3|`body` `end` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
 |R50|3.2.2.3|`body` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
 |R51|3.2.2.3|`body` `dur` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. (NB this will be permitted when `markerMode="continuous"`, a change yet to be implemented in the spec)| |
@@ -63,13 +63,13 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 |R54|3.2.2.4|`div` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R55|3.2.2.4|`div` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R56|3.2.2.4|`div` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
-|R57|3.2.2.4|`div` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
+|R57|3.2.2.4|`div` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R58|3.2.2.4|`div` `end` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R59|3.2.2.4|`div` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R60|3.2.2.5|`p` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R61|3.2.2.5|`p` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R62|3.2.2.5|`p` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
-|R63|3.2.2.5|`p` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
+|R63|3.2.2.5|`p` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R64|3.2.2.5|`p` `end` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R65|3.2.2.5|`p` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R66|3.2.2.6.1|Each distinctly identified facet shall have a separate `facet` element, where facets are identified by combination of the text content and the link attribute.| |

--- a/testing/SPEC-CONFORMANCE.md
+++ b/testing/SPEC-CONFORMANCE.md
@@ -60,12 +60,12 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 |R51|3.2.2.3|`body` `dur` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. (NB this will be permitted when `markerMode="continuous"`, a change yet to be implemented in the spec)| |
 |R52|3.2.2.3|`body` `dur` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
 |R53|3.2.2.3|`body` `dur` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase`|
-|R54|3.2.2.4|`div` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
-|R55|3.2.2.4|`div` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. | |
-|R56|3.2.2.4|`div` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. | |
+|R54|3.2.2.4|`div` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
+|R55|3.2.2.4|`div` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
+|R56|3.2.2.4|`div` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R57|3.2.2.4|`div` `end` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. | |
-|R58|3.2.2.4|`div` `end` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. | |
-|R59|3.2.2.4|`div` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. | |
+|R58|3.2.2.4|`div` `end` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
+|R59|3.2.2.4|`div` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in div`|
 |R60|3.2.2.5|`p` `begin` attribute: If the timebase is "smpte" the type shall be `ebuttdt:smpteTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R61|3.2.2.5|`p` `begin` attribute: If the timebase is "media" the type shall be `ebuttdt:mediaTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R62|3.2.2.5|`p` `begin` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -1,6 +1,6 @@
 Feature: ttp:timeBase-related attribute constraints
 
-  # SPEC-CONFORMANCE: R46 R47 R49 R50 R52 R53
+  # SPEC-CONFORMANCE: R45 R46 R47 R48 R49 R50 R52 R53
   Scenario: Valid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -25,7 +25,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
   # These tests are not all passing because the missing semantic validation piece
-  # SPEC-CONFORMANCE: R46 R47 R49 R50 R52 R53
+  # SPEC-CONFORMANCE: R45 R46 R47 R48 R49 R50 R52 R53
   Scenario: Invalid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -52,7 +52,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     |               |               | 199:00:60.4   |
 
 
-  # SPEC-CONFORMANCE : R55 R56 R58 R59
+  # SPEC-CONFORMANCE : R54 R55 R56 R57 R58 R59
   Scenario: Valid times according to timeBase in div
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -70,7 +70,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | smpte     |               | 08:59:59:99      |
 
 
-  # SPEC-CONFORMANCE : R55 R56 R58 R59
+  # SPEC-CONFORMANCE : R54 R55 R56 R57 R58 R59
   Scenario: Invalid times according to timeBase in div
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -93,7 +93,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     |               |               |
 
 
-  # SPEC-CONFORMANCE: R61 R62 R64 R65
+  # SPEC-CONFORMANCE: R60 R61 R62 R63 R64 R65
   Scenario: Valid times according to timeBase in p
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -111,7 +111,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | smpte     |               | 08:59:59:99      |
 
 
-  # SPEC-CONFORMANCE: R61 R62 R64 R65
+  # SPEC-CONFORMANCE: R60 R61 R62 R63 R64 R65
   @skip
   Scenario: Invalid times according to timeBase in p
     Given an xml file <xml_file>

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -34,14 +34,45 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     | 15.58a        | 1.5d          |               |
     | timeBase_timeformat.xml  | media     | 67.945q       | 125.0x        |               |
     | timeBase_timeformat.xml  | media     |               |               | 99.9l         |
+    | timeBase_timeformat.xml  | media     |               |               | +12.25m       |
     | timeBase_timeformat.xml  | media     | 42:05:08:60.8 | 45:00:47.0    |               |
     | timeBase_timeformat.xml  | media     | 140:09:60.8.1 | 141:00:60.999 |               |
     | timeBase_timeformat.xml  | media     |               |               | 225:59:60.9.3 |
+    | timeBase_timeformat.xml  | media     | -45ms         |               |               |
+    | timeBase_timeformat.xml  | clock     | -45ms         |               |               |
     @skip 
     | timeBase_timeformat.xml  | clock     | 0142:05:60.8  | 145:00:47     |               |
     | timeBase_timeformat.xml  | clock     |               |               | 199:00:60.4   |
 
 
+  Scenario: Valid times according to timeBase in div
+    Given an xml file <xml_file>
+    And it has timeBase <time_base>
+    And it has div begin time <div_begin>
+    And it has div end time <div_end>
+    Then document is valid
+
+    Examples:
+    | xml_file                 | time_base | div_begin     | div_end          |
+    | timeBase_timeformat.xml  | clock     | 999.99m       | 99999999.99s     |
+    | timeBase_timeformat.xml  | clock     | 42:05:60.8    | 45:00:47         |
+    | timeBase_timeformat.xml  | media     | 00.945ms      | 125.0h           |
+    | timeBase_timeformat.xml  | media     | 999:09:60.8   | 001000:00:60.999 |
+
+
+
+  @skip
+  Scenario: Invalid times according to timeBase in div
+    Given an xml file <xml_file>
+    And it has timeBase <time_base>
+    And it has div begin time <div_begin>
+    And it has div end time <div_end>
+    Then document is invalid
+
+    Examples:
+    | xml_file                 | time_base | div_begin     | div_end      |
+    | timeBase_timeformat.xml  | clock     | 099:50:05.4   |              |
+    | timeBase_timeformat.xml  | clock     |               | 245:45:24.54 |
 
 
   Scenario: Valid times according to timeBase in p

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -18,6 +18,8 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | media     | 999:09:60.8 | 1999:00:60.999 |              |
     | timeBase_timeformat.xml  | media     |             |                | 99.9s        |
     | timeBase_timeformat.xml  | media     |             |                | 2225:59:60.9 |
+    | timeBase_timeformat.xml  | smpte     | 15:25:59:65 |                |              |
+    | timeBase_timeformat.xml  | smpte     |             | 23:00:00:99    |              |
 
 
     # These tests are not all passing because the missing semantic validation piece
@@ -40,6 +42,8 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | media     |               |               | 225:59:60.9.3 |
     | timeBase_timeformat.xml  | media     | -45ms         |               |               |
     | timeBase_timeformat.xml  | clock     | -45ms         |               |               |
+    | timeBase_timeformat.xml  | smpte     | 45:25:59:65   |               |               |
+    | timeBase_timeformat.xml  | smpte     |               | 23:00:70:99   |               |
     @skip 
     | timeBase_timeformat.xml  | clock     | 0142:05:60.8  | 145:00:47     |               |
     | timeBase_timeformat.xml  | clock     |               |               | 199:00:60.4   |
@@ -58,10 +62,10 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     | 42:05:60.8    | 45:00:47         |
     | timeBase_timeformat.xml  | media     | 00.945ms      | 125.0h           |
     | timeBase_timeformat.xml  | media     | 999:09:60.8   | 001000:00:60.999 |
+    | timeBase_timeformat.xml  | smpte     | 00:00:00:00   |                  |
+    | timeBase_timeformat.xml  | smpte     |               | 08:59:59:99      |
 
 
-
-  @skip
   Scenario: Invalid times according to timeBase in div
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -70,9 +74,19 @@ Feature: ttp:timeBase-related attribute constraints
     Then document is invalid
 
     Examples:
-    | xml_file                 | time_base | div_begin     | div_end      |
-    | timeBase_timeformat.xml  | clock     | 099:50:05.4   |              |
-    | timeBase_timeformat.xml  | clock     |               | 245:45:24.54 |
+    | xml_file                 | time_base | div_begin     | div_end       |
+    | timeBase_timeformat.xml  | clock     | 15.58a        | 1.5d          |
+    | timeBase_timeformat.xml  | media     | 67.945q       | 125.0x        |
+    | timeBase_timeformat.xml  | media     | 42:05:08:60.8 | 45:00:47.0    |
+    | timeBase_timeformat.xml  | media     | 140:09:60.8.1 | 141:00:60.999 |
+    | timeBase_timeformat.xml  | media     | -45ms         |               |
+    | timeBase_timeformat.xml  | clock     | -45ms         |               |
+    | timeBase_timeformat.xml  | smpte     | 45:25:59:65   |               |
+    | timeBase_timeformat.xml  | smpte     |               | 23:00:70:99   |
+    @skip 
+    | timeBase_timeformat.xml  | clock     | 0142:05:60.8  | 145:00:47     |
+    | timeBase_timeformat.xml  | clock     |               |               |
+
 
 
   Scenario: Valid times according to timeBase in p
@@ -88,10 +102,10 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     | 42:05:60.8    | 45:00:47         |
     | timeBase_timeformat.xml  | media     | 00.945ms      | 125.0h           |
     | timeBase_timeformat.xml  | media     | 999:09:60.8   | 001000:00:60.999 |
+    | timeBase_timeformat.xml  | smpte     | 00:00:00:00   |                  |
+    | timeBase_timeformat.xml  | smpte     |               | 08:59:59:99      |
 
 
-
-  @skip
   Scenario: Invalid times according to timeBase in p
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -100,9 +114,19 @@ Feature: ttp:timeBase-related attribute constraints
     Then document is invalid
 
     Examples:
-    | xml_file                 | time_base | p_begin       | p_end        |
-    | timeBase_timeformat.xml  | clock     | 099:50:05.4   |              |
-    | timeBase_timeformat.xml  | clock     |               | 245:45:24.54 |
+    | xml_file                 | time_base | p_begin       | p_end         |
+    | timeBase_timeformat.xml  | clock     | 15.58a        | 1.5d          |
+    | timeBase_timeformat.xml  | media     | 67.945q       | 125.0x        |
+    | timeBase_timeformat.xml  | media     | 42:05:08:60.8 | 45:00:47.0    |
+    | timeBase_timeformat.xml  | media     | 140:09:60.8.1 | 141:00:60.999 |
+    | timeBase_timeformat.xml  | media     | -45ms         |               |
+    | timeBase_timeformat.xml  | clock     | -45ms         |               |
+    | timeBase_timeformat.xml  | smpte     | 45:25:59:65   |               |
+    | timeBase_timeformat.xml  | smpte     |               | 23:00:70:99   |
+    @skip 
+    | timeBase_timeformat.xml  | clock     | 0142:05:60.8  | 145:00:47     |
+    | timeBase_timeformat.xml  | clock     |               |               |
+
 
 
   Scenario: Valid times according to timeBase in span
@@ -118,10 +142,10 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     | 00:05:60.8     | 45:00:47       |
     | timeBase_timeformat.xml  | media     | 199.45ms       | 15s            |
     | timeBase_timeformat.xml  | media     | 009900:09:60.8 | 1999:00:60.999 |
+    | timeBase_timeformat.xml  | smpte     | 00:00:00:00    |                |
+    | timeBase_timeformat.xml  | smpte     |                | 08:59:59:99    |
 
 
-
-  @skip
   Scenario: Invalid times according to timeBase in span
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -130,6 +154,15 @@ Feature: ttp:timeBase-related attribute constraints
     Then document is invalid
 
     Examples:
-    | xml_file                 | time_base | span_begin | span_end     |
-    | timeBase_timeformat.xml  | clock     | 205:20:19  |              |
-    | timeBase_timeformat.xml  | clock     |            | 045:49:00    |
+    | xml_file                 | time_base | span_begin    | span_end      |
+    | timeBase_timeformat.xml  | clock     | 15.58a        | 1.5d          |
+    | timeBase_timeformat.xml  | media     | 67.945q       | 125.0x        |
+    | timeBase_timeformat.xml  | media     | 42:05:08:60.8 | 45:00:47.0    |
+    | timeBase_timeformat.xml  | media     | 140:09:60.8.1 | 141:00:60.999 |
+    | timeBase_timeformat.xml  | media     | -45ms         |               |
+    | timeBase_timeformat.xml  | clock     | -45ms         |               |
+    | timeBase_timeformat.xml  | smpte     | 45:25:59:65   |               |
+    | timeBase_timeformat.xml  | smpte     |               | 23:00:70:99   |
+    @skip 
+    | timeBase_timeformat.xml  | clock     | 0142:05:60.8  | 145:00:47     |
+    | timeBase_timeformat.xml  | clock     |               |               |

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -49,7 +49,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     |               |               | 199:00:60.4   |
 
 
-  # SPEC-CONFORMANCE :
+  # SPEC-CONFORMANCE : R55 R56 R58 R59
   Scenario: Valid times according to timeBase in div
     Given an xml file <xml_file>
     And it has timeBase <time_base>

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -22,7 +22,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | smpte     |             | 23:00:00:99    |              |
 
 
-    # These tests are not all passing because the missing semantic validation piece
+  # These tests are not all passing because the missing semantic validation piece
   Scenario: Invalid times according to timeBase
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -49,6 +49,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     |               |               | 199:00:60.4   |
 
 
+  # SPEC-CONFORMANCE :
   Scenario: Valid times according to timeBase in div
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -66,6 +67,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | smpte     |               | 08:59:59:99      |
 
 
+  # SPEC-CONFORMANCE : R55 R56 R58 R59
   Scenario: Invalid times according to timeBase in div
     Given an xml file <xml_file>
     And it has timeBase <time_base>
@@ -83,7 +85,7 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml  | clock     | -45ms         |               |
     | timeBase_timeformat.xml  | smpte     | 45:25:59:65   |               |
     | timeBase_timeformat.xml  | smpte     |               | 23:00:70:99   |
-    @skip 
+    @skip
     | timeBase_timeformat.xml  | clock     | 0142:05:60.8  | 145:00:47     |
     | timeBase_timeformat.xml  | clock     |               |               |
 

--- a/testing/bdd/templates/timeBase_timeformat.xml
+++ b/testing/bdd/templates/timeBase_timeformat.xml
@@ -7,7 +7,7 @@
         ttp:frameRate="25"
         ttp:frameRateMultiplier="1 1"
         ttp:dropMode="nonDrop"
-        ttp:markerMode="discontinuous"
+        ttp:markerMode="continuous"
 {% endif %}
 {% if time_base == 'clock' %}
         ttp:clockMode='local'

--- a/testing/bdd/templates/timeBase_timeformat.xml
+++ b/testing/bdd/templates/timeBase_timeformat.xml
@@ -47,7 +47,21 @@
   {% endif %}
 {% endif %}
     >
-    <tt:div>
+    <tt:div
+{% if div_begin %}
+  {% if div_begin == "*?Empty?*" %}
+        tt:begin=""
+  {% else %}
+        tt:begin="{{ div_begin }}"
+  {% endif %}
+{% endif %}
+{% if div_end %}
+  {% if div_end == "*?Empty?*" %}
+        tt:end=""
+  {% else %}
+        tt:end="{{ div_end }}"
+  {% endif %}
+{% endif %}>
       <tt:p
 {% if p_begin %}
   {% if p_begin == "*?Empty?*" %}

--- a/testing/bdd/templates/timeBase_timeformat.xml
+++ b/testing/bdd/templates/timeBase_timeformat.xml
@@ -5,6 +5,9 @@
         ttp:timeBase="{{ time_base }}"
 {% if time_base == 'smpte' %}
         ttp:frameRate="25"
+        ttp:frameRateMultiplier="1 1"
+        ttp:dropMode="nonDrop"
+        ttp:markerMode="discontinuous"
 {% endif %}
 {% if time_base == 'clock' %}
         ttp:clockMode='local'

--- a/testing/bdd/test_timeBase_timeformat.py
+++ b/testing/bdd/test_timeBase_timeformat.py
@@ -23,6 +23,16 @@ def given_body_dur(body_dur, template_dict):
     template_dict['body_dur'] = body_dur
 
 
+@given('it has div begin time <div_begin>')
+def given_div_begin(div_begin, template_dict):
+    template_dict['div_begin'] = div_begin
+
+
+@given('it has div end time <div_end>')
+def given_div_end(div_end, template_dict):
+    template_dict['div_end'] = div_end
+
+
 @given('it has p begin time <p_begin>')
 def given_p_begin(p_begin, template_dict):
     template_dict['p_begin'] = p_begin


### PR DESCRIPTION
For issue #78 
The conformance file made me realized that tests on div were forgotten. I add the smpte format tests also.