### PR TITLE
Create time metric tests and major fix conversion from document times to timedeltas

### DIFF
--- a/ebu_tt_live/bindings/_ebuttdt.py
+++ b/ebu_tt_live/bindings/_ebuttdt.py
@@ -109,7 +109,7 @@ class FullClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.fullClockTimingTyp
     Extending the string type with conversions to and from timedelta
     """
 
-    _groups_regex = re.compile('([0-9][0-9]+):([0-5][0-9]):([0-5][0-9]|60)(?:\.[0-9]+)?')
+    _groups_regex = re.compile('([0-9][0-9]+):([0-5][0-9]):([0-5][0-9]|60)(?:\.([0-9]+))?')
 
     @classmethod
     def as_timedelta(cls, instance):
@@ -118,8 +118,8 @@ class FullClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.fullClockTimingTyp
         :param instance:
         :return:
         """
-        hours, minutes, seconds = cls._groups_regex.match(instance).groups()
-        return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        hours, minutes, seconds, milliseconds = map(lambda x: int(x), cls._groups_regex.match(instance).groups())
+        return timedelta(hours=hours, minutes=minutes, seconds=seconds, milliseconds=milliseconds)
 
     @classmethod
     def from_timedelta(cls, instance):
@@ -161,8 +161,8 @@ class LimitedClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.limitedClockTim
         :param instance:
         :return:
         """
-        hours, minutes, seconds,  = cls._groups_regex.match(instance).groups()
-        return timedelta(hours=hours, minutes=minutes, seconds=seconds)
+        hours, minutes, seconds, milliseconds = map(lambda x: int(x), cls._groups_regex.match(instance).groups())
+        return timedelta(hours=hours, minutes=minutes, seconds=seconds, milliseconds=milliseconds)
 
     @classmethod
     def from_timedelta(cls, instance):

--- a/ebu_tt_live/bindings/_ebuttdt.py
+++ b/ebu_tt_live/bindings/_ebuttdt.py
@@ -152,7 +152,7 @@ class LimitedClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.limitedClockTim
     Extending the string type with conversions to and from timedelta
     """
 
-    _groups_regex = re.compile('([0-9][0-9]):([0-5][0-9]):([0-5][0-9]|60)(?:\.[0-9]+)?')
+    _groups_regex = re.compile('([0-9][0-9]):([0-5][0-9]):([0-5][0-9]|60)(?:\.([0-9]+))?')
 
     @classmethod
     def as_timedelta(cls, instance):
@@ -161,7 +161,7 @@ class LimitedClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.limitedClockTim
         :param instance:
         :return:
         """
-        hours, minutes, seconds = cls._groups_regex.match(instance).groups()
+        hours, minutes, seconds,  = cls._groups_regex.match(instance).groups()
         return timedelta(hours=hours, minutes=minutes, seconds=seconds)
 
     @classmethod

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -64,7 +64,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
   # SPEC-CONFORMANCE: R61 R62 R64 R65
-  
+  @skip
   Scenario: Invalid times according to timeBase in p
     Given an xml file <xml_file>
     And it has timeBase <time_base>

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -64,7 +64,7 @@ Feature: ttp:timeBase-related attribute constraints
 
 
   # SPEC-CONFORMANCE: R61 R62 R64 R65
-  @skip
+  
   Scenario: Invalid times according to timeBase in p
     Given an xml file <xml_file>
     And it has timeBase <time_base>

--- a/testing/bdd/features/validation/time_regex_parsing.feature
+++ b/testing/bdd/features/validation/time_regex_parsing.feature
@@ -1,0 +1,20 @@
+Feature: Regex parsing TimecountTimingType values
+  # Regex for other time types are inderectly checked by 
+
+  # SPEC-CONFORMANCE:
+  Scenario: Valid times according to timeBase
+    Given an xml file <xml_file>
+    And it has timeBase <time_base>
+    And it has body begin time <body_begin>
+    Then timedelta value given when reading body.begin should be <trusted_timedeltas_index>
+    # The trusted array of timedeltas is defined in test_time_regex_parsing.py. Best way found to check
+    # the correctness of the parsing.
+
+    Examples:
+    | xml_file                | time_base | body_begin  | trusted_timedeltas_index |
+    | time_regex_parsing.xml  | clock     | 15h         | 0                        |
+    | time_regex_parsing.xml  | clock     | 30m         | 1                        |
+    | time_regex_parsing.xml  | clock     | 42s         | 2                        |
+    | time_regex_parsing.xml  | clock     | 67ms        | 3                        |
+    | time_regex_parsing.xml  | clock     | 42:05:60.0  | 4                        |
+    | time_regex_parsing.xml  | media     | 999:09:60.0 | 5                        |

--- a/testing/bdd/features/validation/time_regex_parsing.feature
+++ b/testing/bdd/features/validation/time_regex_parsing.feature
@@ -11,10 +11,10 @@ Feature: Regex parsing TimecountTimingType values
     # the correctness of the parsing.
 
     Examples:
-    | xml_file                | time_base | body_begin  | trusted_timedeltas_index |
-    | time_regex_parsing.xml  | clock     | 15h         | 0                        |
-    | time_regex_parsing.xml  | clock     | 30m         | 1                        |
-    | time_regex_parsing.xml  | clock     | 42s         | 2                        |
-    | time_regex_parsing.xml  | clock     | 67ms        | 3                        |
-    | time_regex_parsing.xml  | clock     | 42:05:60.0  | 4                        |
-    | time_regex_parsing.xml  | media     | 999:09:60.0 | 5                        |
+    | xml_file                | time_base | body_begin    | trusted_timedeltas_index |
+    | time_regex_parsing.xml  | clock     | 15h           | 0                        |
+    | time_regex_parsing.xml  | clock     | 30m           | 1                        |
+    | time_regex_parsing.xml  | clock     | 42s           | 2                        |
+    | time_regex_parsing.xml  | clock     | 67ms          | 3                        |
+    | time_regex_parsing.xml  | clock     | 42:05:60.234  | 4                        |
+    | time_regex_parsing.xml  | media     | 999:09:60.005 | 5                        |

--- a/testing/bdd/templates/time_regex_parsing.xml
+++ b/testing/bdd/templates/time_regex_parsing.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<tt:tt
+        ebuttp:sequenceIdentifier="testSequence001"
+        ebuttp:sequenceNumber="1"
+        ttp:timeBase="clock"
+{% if time_base == 'clock' %}
+        ttp:clockMode='local'
+{% endif %}
+        xml:lang="en-GB"
+        xmlns:ebuttm="urn:ebu:tt:metadata"
+        xmlns:ebuttp="urn:ebu:tt:parameters"
+        xmlns:tt="http://www.w3.org/ns/ttml"
+        xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <tt:head>
+    <tt:metadata>
+      <ebuttm:documentMetadata/>
+    </tt:metadata>
+    <tt:styling>
+      <tt:style xml:id="ID001"/>
+    </tt:styling>
+    <tt:layout/>
+  </tt:head>
+  <tt:body 
+{% if body_begin %}
+  {% if body_begin == "*?Empty?*" %}
+      tt:begin=""
+  {% else %}
+      tt:begin="{{ body_begin }}"
+  {% endif %}
+{% endif %}
+    >
+    <tt:div>
+      <tt:p xml:id="ID005">
+            <tt:span>
+              Some example text...
+            </tt:span>
+        <tt:br/>
+        <tt:span>And another line</tt:span>
+      </tt:p>
+    </tt:div>
+  </tt:body>
+</tt:tt>

--- a/testing/bdd/test_time_regex_parsing.py
+++ b/testing/bdd/test_time_regex_parsing.py
@@ -9,8 +9,8 @@ trusted_timedeltas = [
     timedelta(minutes=30),
     timedelta(seconds=42),
     timedelta(milliseconds=67),
-    timedelta(hours=42, minutes=5, seconds=60),
-    timedelta(hours=999, minutes=9, seconds=60)
+    timedelta(hours=42, minutes=5, seconds=60, milliseconds=234),
+    timedelta(hours=999, minutes=9, seconds=60, milliseconds=5)
 ]
 
 
@@ -28,4 +28,4 @@ def given_body_begin(body_begin, template_dict):
 def check_correct_parsing(template_file, template_dict, trusted_timedeltas_index):
     xml_file = template_file.render(template_dict)
     document = EBUTT3Document.create_from_xml(xml_file)
-    assert document._ebutt3_content.body.begin.timedelta() == trusted_timedeltas[trusted_timedeltas_index]
+    assert document._ebutt3_content.body.begin.timedelta == trusted_timedeltas[trusted_timedeltas_index]

--- a/testing/bdd/test_time_regex_parsing.py
+++ b/testing/bdd/test_time_regex_parsing.py
@@ -1,0 +1,31 @@
+from ebu_tt_live.documents import EBUTT3Document
+from datetime import timedelta
+from pytest_bdd import scenarios, given, then
+
+scenarios('features/validation/time_regex_parsing.feature', example_converters=dict(trusted_timedeltas_index=int))
+
+trusted_timedeltas = [
+    timedelta(hours=15),
+    timedelta(minutes=30),
+    timedelta(seconds=42),
+    timedelta(milliseconds=67),
+    timedelta(hours=42, minutes=5, seconds=60),
+    timedelta(hours=999, minutes=9, seconds=60)
+]
+
+
+@given('it has timeBase <time_base>')
+def given_time_base(time_base, template_dict):
+    template_dict['time_base'] = time_base
+
+
+@given('it has body begin time <body_begin>')
+def given_body_begin(body_begin, template_dict):
+    template_dict['body_begin'] = body_begin
+
+
+@then('timedelta value given when reading body.begin should be <trusted_timedeltas_index>')
+def check_correct_parsing(template_file, template_dict, trusted_timedeltas_index):
+    xml_file = template_file.render(template_dict)
+    document = EBUTT3Document.create_from_xml(xml_file)
+    assert document._ebutt3_content.body.begin.timedelta() == trusted_timedeltas[trusted_timedeltas_index]


### PR DESCRIPTION
Major fix for converting times from documents to timedeltas with tests. Fix for issues #69 , #82 , #83 