### PR TITLE
User input forwarder

### DIFF
--- a/ebu_tt_live/carriage/filesystem.py
+++ b/ebu_tt_live/carriage/filesystem.py
@@ -63,7 +63,6 @@ class FilesystemProducerImpl(ProducerCarriageImpl):
 
     _manifest_path = None
     _dirpath = None
-    _manifest_file = None
     _manifest_content = None
     _manifest_time_format = None
 
@@ -93,6 +92,9 @@ class FilesystemProducerImpl(ProducerCarriageImpl):
                 break
 
     def emit_document(self, document):
+        if self._manifest_path is None:
+            manifest_filename = "manifest_" + document.sequence_identifier + ".txt"
+            self._manifest_path = os.path.join(self._dirpath, manifest_filename)
         # Handle there the switch and checks to handle the string format to use
         # for times in the manifest file depending on your time base.
         filename = '{}_{}.xml'.format(document.sequence_identifier, document.sequence_number)

--- a/ebu_tt_live/carriage/forwarder_carriage.py
+++ b/ebu_tt_live/carriage/forwarder_carriage.py
@@ -1,7 +1,7 @@
 from .base import CombinedCarriageImpl
 
 
-class ForwarderCarriage(CombinedCarriageImpl):
+class ForwarderCarriageImpl(CombinedCarriageImpl):
 
     _consumer_carriage = None
     _producer_carriage = None

--- a/ebu_tt_live/carriage/forwarder_carriage.py
+++ b/ebu_tt_live/carriage/forwarder_carriage.py
@@ -1,0 +1,22 @@
+from .base import CombinedCarriageImpl
+
+
+class ForwarderCarriage(CombinedCarriageImpl):
+
+    _consumer_carriage = None
+    _producer_carriage = None
+
+    def __init__(self, consumer_carriage, producer_carriage):
+        self._consumer_carriage = consumer_carriage
+        self._producer_carriage = producer_carriage
+
+    def register(self, node):
+        self._node = node
+        self._consumer_carriage.register(node)
+        self._producer_carriage.register(node)
+
+    def emit_document(self, document):
+        self._producer_carriage.emit_document(document)
+
+    def on_new_data(self, data):
+        self._consumer_carriage.on_new_data(data)

--- a/ebu_tt_live/carriage/test/test_forwarder_carriage.py
+++ b/ebu_tt_live/carriage/test/test_forwarder_carriage.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from mock import MagicMock
+from ebu_tt_live.carriage.forwarder_carriage import ForwarderCarriageImpl
+
+
+class TestForwarderCarriageImpl(TestCase):
+
+    def setUp(self):
+        self.consumer_impl = MagicMock()
+        self.producer_impl = MagicMock()
+        self.node = MagicMock()
+
+    def test_register(self):
+        forwarder_impl = ForwarderCarriageImpl(self.consumer_impl, self.producer_impl)
+        forwarder_impl.register(self.node)
+        self.consumer_impl.register.assert_called_with(self.node)
+        self.producer_impl.register.assert_called_with(self.node)
+
+    def test_emit_document(self):
+        forwarder_impl = ForwarderCarriageImpl(self.consumer_impl, self.producer_impl)
+        document = MagicMock()
+        forwarder_impl.emit_document(document)
+        self.producer_impl.emit_document.assert_called_with(document)
+
+    def test_on_new_data(self):
+        forwarder_impl = ForwarderCarriageImpl(self.consumer_impl, self.producer_impl)
+        data = MagicMock()
+        forwarder_impl.on_new_data(data)
+        self.consumer_impl.on_new_data.assert_called_with(data)
+

--- a/ebu_tt_live/carriage/test/test_forwarder_carriage.py
+++ b/ebu_tt_live/carriage/test/test_forwarder_carriage.py
@@ -27,4 +27,3 @@ class TestForwarderCarriageImpl(TestCase):
         data = MagicMock()
         forwarder_impl.on_new_data(data)
         self.consumer_impl.on_new_data.assert_called_with(data)
-

--- a/ebu_tt_live/node/distributing.py
+++ b/ebu_tt_live/node/distributing.py
@@ -1,0 +1,28 @@
+from .base import Node
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
+class DistributingNode(Node):
+
+    _reference_clock = None
+
+    def __init__(self, node_id, carriage_impl, reference_clock):
+        super(DistributingNode, self).__init__(node_id, carriage_impl)
+        self._reference_clock = reference_clock
+
+    def process_document(self, document):
+        log.info(document)
+        log.info(" " + str(document.sequence_identifier) + "_" + str(document.sequence_number))
+        log.info(document.get_xml())
+        self._carriage_impl.emit_document(document)
+
+    @property
+    def reference_clock(self):
+        return self._reference_clock
+
+    @reference_clock.setter
+    def reference_clock(self, value):
+        self._reference_clock = value

--- a/ebu_tt_live/node/test/test_distributing.py
+++ b/ebu_tt_live/node/test/test_distributing.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+from mock import MagicMock
+from ebu_tt_live.node.distributing import DistributingNode
+
+
+class TestDistributingNode(TestCase):
+
+    def test_process_document(self):
+        carriage = MagicMock()
+        reference_clock = MagicMock()
+        node = DistributingNode('distributing_node', carriage, reference_clock)
+        document = MagicMock()
+        node.process_document(document)
+        carriage.emit_document.assert_called_with(document)

--- a/ebu_tt_live/scripts/ebu_user_input_consumer.py
+++ b/ebu_tt_live/scripts/ebu_user_input_consumer.py
@@ -36,7 +36,7 @@ def main():
     )
 
     factory = UserInputServerFactory(
-        url='ws://127.0.0.1:9000',
+        url='ws://127.0.0.1:9001',
         consumer=TwistedConsumer(
             custom_consumer=consumer_impl
         )

--- a/ebu_tt_live/scripts/ebu_user_input_forwarder.py
+++ b/ebu_tt_live/scripts/ebu_user_input_forwarder.py
@@ -1,0 +1,60 @@
+import logging
+from argparse import ArgumentParser
+from .common import create_loggers
+
+from ebu_tt_live.node.distributing import DistributingNode
+from ebu_tt_live.clocks.local import LocalMachineClock
+from ebu_tt_live.twisted import TwistedConsumer, UserInputServerProtocol, UserInputServerFactory, BroadcastServerFactory, TwistedPullProducer, StreamingServerProtocol
+from ebu_tt_live.carriage.forwarder_carriage import ForwarderCarriage
+from ebu_tt_live.carriage.twisted import TwistedConsumerImpl, TwistedProducerImpl
+from twisted.internet import reactor
+
+
+log = logging.getLogger('ebu_simple_consumer')
+
+
+parser = ArgumentParser()
+
+parser.add_argument('-c', '--config', dest='config', metavar='CONFIG')
+
+
+def main():
+    # args = parser.parse_args()
+    create_loggers()
+    log.info('This is a Simple Consumer example')
+
+    sub_consumer_impl = TwistedConsumerImpl()
+    sub_prod_impl = TwistedProducerImpl()
+    carriage_impl = ForwarderCarriage(sub_consumer_impl, sub_prod_impl)
+
+    reference_clock = LocalMachineClock()
+    reference_clock.clock_mode = 'local'
+
+    dist_node = DistributingNode(
+        node_id='simple-consumer',
+        carriage_impl=carriage_impl,
+        reference_clock=reference_clock
+    )
+
+    user_input_server_factory = UserInputServerFactory(
+        url='ws://127.0.0.1:9001',
+        consumer=TwistedConsumer(
+            custom_consumer=sub_consumer_impl
+        )
+    )
+    user_input_server_factory.protocol = UserInputServerProtocol
+
+    user_input_server_factory.listen()
+
+    broadcast_factory = BroadcastServerFactory("ws://127.0.0.1:9000")
+
+    broadcast_factory.protocol = StreamingServerProtocol
+
+    broadcast_factory.listen()
+
+    TwistedPullProducer(
+        consumer=broadcast_factory,
+        custom_producer=sub_prod_impl
+    )
+
+    reactor.run()

--- a/ebu_tt_live/scripts/ebu_user_input_forwarder.py
+++ b/ebu_tt_live/scripts/ebu_user_input_forwarder.py
@@ -43,7 +43,7 @@ def main():
     reference_clock.clock_mode = 'local'
 
     dist_node = DistributingNode(
-        node_id='simple-consumer',
+        node_id='distributing-node',
         carriage_impl=carriage_impl,
         reference_clock=reference_clock
     )

--- a/ebu_tt_live/scripts/ebu_user_input_forwarder.py
+++ b/ebu_tt_live/scripts/ebu_user_input_forwarder.py
@@ -5,7 +5,7 @@ from .common import create_loggers
 from ebu_tt_live.node.distributing import DistributingNode
 from ebu_tt_live.clocks.local import LocalMachineClock
 from ebu_tt_live.twisted import TwistedConsumer, UserInputServerProtocol, UserInputServerFactory, BroadcastServerFactory, TwistedPullProducer, StreamingServerProtocol
-from ebu_tt_live.carriage.forwarder_carriage import ForwarderCarriage
+from ebu_tt_live.carriage.forwarder_carriage import ForwarderCarriageImpl
 from ebu_tt_live.carriage.filesystem import FilesystemProducerImpl
 from ebu_tt_live.carriage.twisted import TwistedConsumerImpl, TwistedProducerImpl
 from twisted.internet import reactor
@@ -22,6 +22,7 @@ parser.add_argument('--folder-export', dest='folder_export',
                     type=str
                     )
 
+
 def main():
     args = parser.parse_args()
     create_loggers()
@@ -36,7 +37,7 @@ def main():
         sub_prod_impl = FilesystemProducerImpl(args.folder_export)
     else:
         sub_prod_impl = TwistedProducerImpl()
-    carriage_impl = ForwarderCarriage(sub_consumer_impl, sub_prod_impl)
+    carriage_impl = ForwarderCarriageImpl(sub_consumer_impl, sub_prod_impl)
 
     reference_clock = LocalMachineClock()
     reference_clock.clock_mode = 'local'

--- a/ebu_tt_live/scripts/ebu_user_input_forwarder.py
+++ b/ebu_tt_live/scripts/ebu_user_input_forwarder.py
@@ -36,6 +36,7 @@ def main():
         reference_clock=reference_clock
     )
 
+    # This factory listens for incoming documents from the user input producer.
     user_input_server_factory = UserInputServerFactory(
         url='ws://127.0.0.1:9001',
         consumer=TwistedConsumer(
@@ -43,13 +44,11 @@ def main():
         )
     )
     user_input_server_factory.protocol = UserInputServerProtocol
-
     user_input_server_factory.listen()
 
+    # This factory listens for any consumer to forward documents to.
     broadcast_factory = BroadcastServerFactory("ws://127.0.0.1:9000")
-
     broadcast_factory.protocol = StreamingServerProtocol
-
     broadcast_factory.listen()
 
     TwistedPullProducer(

--- a/ebu_tt_live/ui/user_input_producer/user_input_producer.html
+++ b/ebu_tt_live/ui/user_input_producer/user_input_producer.html
@@ -514,9 +514,12 @@
                   var rendered_document = nunjucks.render('ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.xml', template_data);
                   setTimeout(renderSendDocument, timeout, rendered_document);
                   notifySuccess($("#scheduled-confirmation-span"), "Scheduled...", true);
+                  sequence_numbers[sequence_identifier] += 1;
                } else {
                   renderSendDocument();
+                  sequence_numbers[sequence_identifier] += 1;
                }
+               localStorage.sequence_numbers = JSON.stringify(sequence_numbers);
             }
 
             function renderSendDocument(doc=null) {
@@ -533,8 +536,6 @@
                } else {
                   notifyError($("#subtitle-form-notification-div"), "Error: there is no connection to the websocket server !", false);
                }
-               sequence_numbers[sequence_identifier] += 1;
-               localStorage.sequence_numbers = JSON.stringify(sequence_numbers);
             }
 
             $("#submit-subtitle-button").click(function(){

--- a/ebu_tt_live/ui/user_input_producer/user_input_producer.html
+++ b/ebu_tt_live/ui/user_input_producer/user_input_producer.html
@@ -55,7 +55,7 @@
       <span id="new-sequence-notification-span"></span>
       <br><br>
       <label for="websocket-url-input">Websocket server URL: </label>
-      <input type="url" id="websocket-url-input" name="websocket-url-input" value="ws://127.0.0.1:9000" required>
+      <input type="url" id="websocket-url-input" name="websocket-url-input" value="ws://127.0.0.1:9001" required>
       <button type="button" id="websocket-connect-button" name="websocket-connect-button">Connect</button>
       <button type="button" id="websocket-disconnect-button" name="websocket-disconnect-button" style="display: none">Disconnect</button>
       <span id="websocket-notifications-span" style="color: orange">Disconnected</span>

--- a/ebu_tt_live/ui/user_input_producer/user_input_producer.html
+++ b/ebu_tt_live/ui/user_input_producer/user_input_producer.html
@@ -428,7 +428,7 @@
             $("#asynchronous-send-start-button").click( function() {
                if (!interval_send) {
                   var interval = parseInt($("#asynchronous-send-interval-input").val());
-                  interval_send = setInterval(renderSendDocument, interval*1000);
+                  interval_send = setInterval(asyncSubmit, interval*1000);
                   notifySuccess($("#asynchronous-send-status-span"), "Running...", false);
                }
             });
@@ -519,6 +519,14 @@
                   renderSendDocument();
                   sequence_numbers[sequence_identifier] += 1;
                }
+               localStorage.sequence_numbers = JSON.stringify(sequence_numbers);
+            }
+
+            function asyncSubmit() {
+               var template_data = createTemplateDict();
+               var rendered_document = nunjucks.render('ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.xml', template_data);
+               renderSendDocument(rendered_document);
+               sequence_numbers[sequence_identifier] += 1;
                localStorage.sequence_numbers = JSON.stringify(sequence_numbers);
             }
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
             'ebu-interactive-shell = ebu_tt_live.scripts.ebu_interactive_shell:main',
             'ebu-simple-consumer = ebu_tt_live.scripts.ebu_simple_consumer:main',
             'ebu-simple-producer = ebu_tt_live.scripts.ebu_simple_producer:main',
-            'ebu-user-input-consumer = ebu_tt_live.scripts.ebu_user_input_consumer:main'
+            'ebu-user-input-consumer = ebu_tt_live.scripts.ebu_user_input_consumer:main',
+            'ebu-user-input-forwarder = ebu_tt_live.scripts.ebu_user_input_forwarder:main'
         ]
     },
     **extra


### PR DESCRIPTION
A first try at the user input forwarder. So we have a new node that receives the document and forwards it further (by calling `emit_document` in its `process_document` function).

I created a new carriage class inheriting from `CombinedCarriageImpl` and having two attributes : a consumer carriage and a producer carriage. This allows me reuse existing code by using existing carriage implementations.

You can test it, start `ebu-user-input-forwarder` script, then open the User input producer UI and the `test.html` file. Create a sequence in the UIP and use it as the channel name in `test.html` when subscribing. Normally when you send documents from the UIP it shows up in `test.html`

@nigelmegitt : Is this the way you imagined this component ?
@kozmaz87 : what do you think of my solution ?

This version shows that changing the destination of the documents is really easy, simply modify the `ebu-user-input-forwarder` with another `sub_prod_impl` to have a new carriage.

@nigelmegitt : did you imagine a script with command line options to define how to handle documents ? (websocket, filesystem, ....). If yes, I can do it, it is quite easy to do.

Fix #126 