### PR TITLE
Bdd/sequence identical timing model

### DIFF
--- a/ebu_tt_live/clocks/local.py
+++ b/ebu_tt_live/clocks/local.py
@@ -5,6 +5,7 @@ from .base import Clock
 class LocalMachineClock(Clock):
 
     _time_base = 'clock'
+    _clock_mode = 'local'
 
     def get_real_clock_time(self):
         now = datetime.now().time()

--- a/ebu_tt_live/documents/ebutt3.py
+++ b/ebu_tt_live/documents/ebutt3.py
@@ -331,10 +331,16 @@ class EBUTT3DocumentSequence(CloningDocumentSequence):
         )
 
     def _check_document_compatibility(self, document):
-        if self.sequence_identifier != document.sequence_identifier:
+        if self.sequence_identifier != document.sequence_identifier or \
+                self._reference_clock.time_base != document.time_base:
             raise IncompatibleSequenceError(
                 ERR_DOCUMENT_NOT_COMPATIBLE
             )
+        if self._reference_clock.time_base == 'clock':
+            if self._reference_clock.clock_mode != document.clock_mode:
+                raise IncompatibleSequenceError(
+                    ERR_DOCUMENT_NOT_COMPATIBLE
+                )
         return True
 
     def new_document(self, *args, **kwargs):

--- a/testing/SPEC-CONFORMANCE.md
+++ b/testing/SPEC-CONFORMANCE.md
@@ -17,7 +17,7 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 | R8|2.2 |Every distinct document with the same sequence identifier shall have a different sequence number.| |
 | R9|2.2 |Sequence numbers shall increase with the passage of time for each new document that is made available.| |
 |R10|2.2 |Every document in a sequence shall be valid and self-contained.| |
-|R11|2.2 |Every document in a sequence shall have an identical timing model as defined by using the same values for the `ttp:timeBase` and `ttp:clockMode` attributes. (Note issue to add `frameRate`, `frameRateMultiplier` and `dropMode` to this attribute set)| |
+|R11|2.2 |Every document in a sequence shall have an identical timing model as defined by using the same values for the `ttp:timeBase` and `ttp:clockMode` attributes. (Note issue to add `frameRate`, `frameRateMultiplier` and `dropMode` to this attribute set)|`bdd/features/validation/sequence\_identical\_timing\_model.feature` `(Not) compatible document`|
 |R12|2.2 |A passive node shall NOT modify input sequences and shall only emit sequences that are identical (including the sequence numbers) to the input sequence(s)| |
 |R13|2.2 |At any moment in the presentation of a sequence by a node exactly zero or one document shall be temporally active.| |
 |R14|2.3.1|At any single moment in time during the presentation of a sequence either zero documents or one document shall be active.| |

--- a/testing/bdd/features/validation/sequence_identical_timing_model.feature
+++ b/testing/bdd/features/validation/sequence_identical_timing_model.feature
@@ -1,0 +1,71 @@
+@validation @sequence
+Feature: Every document in a sequence shall have an identical timing model as defined by using the same values for the 
+  ttp:timeBase, ttp:clockMode, frameRate, frameRateMultiplier and dropMode attributes.
+
+  Examples:
+  | xml_file                             |
+  | sequence_identical_timing_model.xml |
+
+  # SPEC-CONFORMANCE: R11
+  # This is not checked when the document is added to the sequence, so skipped for now.
+  @skip
+  Scenario: Not compatible document
+    Given a test sequence
+    And an xml file <xml_file>
+    When it has sequenceNumber 1
+    And it has timeBase <time_base1>
+    And it has clockMode <clock_mode1>
+    And it has frameRate <frame_rate1>
+    And it has frameRateMultiplier <frame_rate_multiplier1>
+    And it has dropMode <drop_mode1>
+    And it has markerMode <marker_mode1>
+    And doc1 is added to the sequence
+    And we create a new document
+    And it has sequenceNumber 2
+    And it has timeBase <time_base2>
+    And it has clockMode <clock_mode2>
+    And it has frameRate <frame_rate2>
+    And it has frameRateMultiplier <frame_rate_multiplier2>
+    And it has dropMode <drop_mode2>
+    And it has markerMode <marker_mode2>
+    Then adding doc2 to the sequence results in an error
+
+    Examples:
+    | time_base1 | clock_mode1 | frame_rate1 | frame_rate_multiplier1 | drop_mode1 | marker_mode1 | time_base2 | clock_mode2 | frame_rate2 | frame_rate_multiplier2 | drop_mode2 | marker_mode2 |
+    | clock      | local       |             |                        |            |              | clock      | utc         |             |                        |            |              |
+    | clock      | utc         |             |                        |            |              | clock      | gps         |             |                        |            |              |
+    | clock      | gps         |             |                        |            |              | clock      | local       |             |                        |            |              |
+    | media      |             |             |                        |            |              | clock      | local       |             |                        |            |              |
+    | clock      | local       |             |                        |            |              | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
+    | media      |             |             |                        |            |              | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
+
+
+  # SPEC-CONFORMANCE: R11
+  Scenario: Compatible document
+    Given a test sequence
+    And an xml file <xml_file>
+    When it has sequenceNumber 1
+    And it has timeBase <time_base1>
+    And it has clockMode <clock_mode1>
+    And it has frameRate <frame_rate1>
+    And it has frameRateMultiplier <frame_rate_multiplier1>
+    And it has dropMode <drop_mode1>
+    And it has markerMode <marker_mode1>
+    And doc1 is added to the sequence
+    And we create a new document
+    And it has sequenceNumber 2
+    And it has timeBase <time_base2>
+    And it has clockMode <clock_mode2>
+    And it has frameRate <frame_rate2>
+    And it has frameRateMultiplier <frame_rate_multiplier2>
+    And it has dropMode <drop_mode2>
+    And it has markerMode <marker_mode2>
+    Then adding doc2 to the sequence does not raise any error
+
+    Examples:
+    | time_base1 | clock_mode1 | frame_rate1 | frame_rate_multiplier1 | drop_mode1 | marker_mode1 | time_base2 | clock_mode2 | frame_rate2 | frame_rate_multiplier2 | drop_mode2 | marker_mode2 |
+    | clock      | local       |             |                        |            |              | clock      | local       |             |                        |            |              |
+    | clock      | utc         |             |                        |            |              | clock      | utc         |             |                        |            |              |
+    | clock      | gps         |             |                        |            |              | clock      | gps         |             |                        |            |              |
+    | media      |             |             |                        |            |              | media      |             |             |                        |            |              |
+    | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |

--- a/testing/bdd/features/validation/sequence_identical_timing_model.feature
+++ b/testing/bdd/features/validation/sequence_identical_timing_model.feature
@@ -38,6 +38,9 @@ Feature: Every document in a sequence shall have an identical timing model as de
     | media      |             |             |                        |            |              | clock      | local       |             |                        |            |              |
     | clock      | local       |             |                        |            |              | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
     | media      |             |             |                        |            |              | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
+    | smpte      | smpte       | 20          | 1 1                    | nonDrop    | continuous   | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
+    | smpte      | smpte       | 30          | 1000 1001              | dropPal    | continuous   | smpte      |             | 30          | 1 1                    | nonDrop    | continuous   |
+    | smpte      | smpte       | 30          | 1000 1001              | dropPal    | continuous   | smpte      |             | 30          | 1000 1001              | dropNTSC   | continuous   |
 
 
   # SPEC-CONFORMANCE: R11

--- a/testing/bdd/features/validation/sequence_identical_timing_model.feature
+++ b/testing/bdd/features/validation/sequence_identical_timing_model.feature
@@ -68,6 +68,7 @@ Feature: Every document in a sequence shall have an identical timing model as de
     Examples:
     | time_base1 | clock_mode1 | frame_rate1 | frame_rate_multiplier1 | drop_mode1 | marker_mode1 | time_base2 | clock_mode2 | frame_rate2 | frame_rate_multiplier2 | drop_mode2 | marker_mode2 |
     | clock      | local       |             |                        |            |              | clock      | local       |             |                        |            |              |
+    @skip
     | clock      | utc         |             |                        |            |              | clock      | utc         |             |                        |            |              |
     | clock      | gps         |             |                        |            |              | clock      | gps         |             |                        |            |              |
     | media      |             |             |                        |            |              | media      |             |             |                        |            |              |

--- a/testing/bdd/features/validation/sequence_identical_timing_model.feature
+++ b/testing/bdd/features/validation/sequence_identical_timing_model.feature
@@ -7,8 +7,7 @@ Feature: Every document in a sequence shall have an identical timing model as de
   | sequence_identical_timing_model.xml |
 
   # SPEC-CONFORMANCE: R11
-  # This is not checked when the document is added to the sequence, so skipped for now.
-  @skip
+  # GPS clock and SMPTE clock are not implemented yet so all the corresponding tests are skipped.
   Scenario: Not compatible document
     Given a test sequence
     And an xml file <xml_file>
@@ -34,8 +33,9 @@ Feature: Every document in a sequence shall have an identical timing model as de
     | time_base1 | clock_mode1 | frame_rate1 | frame_rate_multiplier1 | drop_mode1 | marker_mode1 | time_base2 | clock_mode2 | frame_rate2 | frame_rate_multiplier2 | drop_mode2 | marker_mode2 |
     | clock      | local       |             |                        |            |              | clock      | utc         |             |                        |            |              |
     | clock      | utc         |             |                        |            |              | clock      | gps         |             |                        |            |              |
-    | clock      | gps         |             |                        |            |              | clock      | local       |             |                        |            |              |
     | media      |             |             |                        |            |              | clock      | local       |             |                        |            |              |
+    @skip
+    | clock      | gps         |             |                        |            |              | clock      | local       |             |                        |            |              |
     | clock      | local       |             |                        |            |              | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
     | media      |             |             |                        |            |              | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
     | smpte      | smpte       | 20          | 1 1                    | nonDrop    | continuous   | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |
@@ -68,8 +68,8 @@ Feature: Every document in a sequence shall have an identical timing model as de
     Examples:
     | time_base1 | clock_mode1 | frame_rate1 | frame_rate_multiplier1 | drop_mode1 | marker_mode1 | time_base2 | clock_mode2 | frame_rate2 | frame_rate_multiplier2 | drop_mode2 | marker_mode2 |
     | clock      | local       |             |                        |            |              | clock      | local       |             |                        |            |              |
-    @skip
     | clock      | utc         |             |                        |            |              | clock      | utc         |             |                        |            |              |
+    @skip
     | clock      | gps         |             |                        |            |              | clock      | gps         |             |                        |            |              |
     | media      |             |             |                        |            |              | media      |             |             |                        |            |              |
     | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   | smpte      |             | 25          | 1 1                    | nonDrop    | continuous   |

--- a/testing/bdd/templates/sequence_identical_timing_model.xml
+++ b/testing/bdd/templates/sequence_identical_timing_model.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<tt:tt
+        ebuttp:sequenceIdentifier="TestSequence1"
+        ebuttp:sequenceNumber="1"
+        ttp:timeBase="{{ time_base }}"
+{% if time_base == "clock" %}
+        ttp:clockMode="{{clock_mode}}"
+{% endif %}
+{% if time_base == "smpte" %}
+        ttp:frameRate="{{frame_rate}}"
+        ttp:frameRateMultiplier="{{frame_rate_multiplier}}"
+        ttp:dropMode="{{drop_mode}}"
+        ttp:markerMode="{{marker_mode}}"
+{% endif %}
+        xml:lang="en-GB"
+        xmlns:ebuttm="urn:ebu:tt:metadata"
+        xmlns:ebuttp="urn:ebu:tt:parameters"
+        xmlns:tt="http://www.w3.org/ns/ttml"
+        xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <tt:head>
+    <tt:metadata>
+      <ebuttm:documentMetadata/>
+    </tt:metadata>
+    <tt:styling>
+      <tt:style xml:id="ID001"/>
+    </tt:styling>
+    <tt:layout/>
+  </tt:head>
+  <tt:body>
+    <tt:div>
+      <tt:p xml:id="ID005">
+        <tt:span>Some example text...</tt:span>
+        <tt:br/>
+        <tt:span>And another line</tt:span>
+      </tt:p>
+    </tt:div>
+  </tt:body>
+</tt:tt>

--- a/testing/bdd/test_sequence_identical_timing_model.py
+++ b/testing/bdd/test_sequence_identical_timing_model.py
@@ -1,0 +1,115 @@
+from ebu_tt_live.documents import EBUTT3Document, EBUTT3DocumentSequence
+from pytest_bdd import given, when, then, scenarios, parsers
+import pytest
+
+
+scenarios('features/validation/sequence_identical_timing_model.feature')
+
+
+# We cannot use a sequence fixture here like in other sequence tests because
+# the sequence is created later from the first document and assigning a fixture
+# after its creation function is not possible. So we store the documents in an
+# array and create the sequence in the final thens
+@given('a test sequence')
+def doc_list(template_dict):
+    doc_list = []
+    return doc_list
+
+
+@when(parsers.parse('it has sequenceNumber {sequence_number}'))
+def when_sequence_number(sequence_number, template_dict):
+    template_dict['sequence_number'] = sequence_number
+
+
+@when('it has timeBase <time_base1>')
+def when_time_base1(time_base1, template_dict):
+    template_dict['time_base'] = time_base1
+
+
+@when('it has clockMode <clock_mode1>')
+def when_clock_mode1(clock_mode1, template_dict):
+    template_dict['clock_mode'] = clock_mode1
+
+
+@when('it has frameRate <frame_rate1>')
+def when_frame_rate1(frame_rate1, template_dict):
+    template_dict['frame_rate'] = frame_rate1
+
+
+@when('it has frameRateMultiplier <frame_rate_multiplier1>')
+def when_frame_rate_multiplier1(frame_rate_multiplier1, template_dict):
+    template_dict['frame_rate_multiplier'] = frame_rate_multiplier1
+
+
+@when('it has dropMode <drop_mode1>')
+def when_drop_mode1(drop_mode1, template_dict):
+    template_dict['drop_mode'] = drop_mode1
+
+
+@when('it has markerMode <marker_mode1>')
+def when_marker_mode1(marker_mode1, template_dict):
+    template_dict['marker_mode'] = marker_mode1
+
+
+@when('doc1 is added to the sequence')
+def when_doc1_added_to_sequence(doc_list, template_file, template_dict):
+    xml_file = template_file.render(template_dict)
+    document = EBUTT3Document.create_from_xml(xml_file)
+    doc_list.append(document)
+
+
+@when('we create a new document')
+def when_create_new_document(template_dict):
+    template_dict['sequence_num'] = None
+
+
+@when('it has timeBase <time_base2>')
+def when_time_base2(time_base2, template_dict):
+    template_dict['time_base'] = time_base2
+
+
+@when('it has clockMode <clock_mode2>')
+def when_clock_mode2(clock_mode2, template_dict):
+    template_dict['clock_mode'] = clock_mode2
+
+
+@when('it has frameRate <frame_rate2>')
+def when_frame_rate2(frame_rate2, template_dict):
+    template_dict['frame_rate'] = frame_rate2
+
+
+@when('it has frameRateMultiplier <frame_rate_multiplier2>')
+def when_frame_rate_multiplier2(frame_rate_multiplier2, template_dict):
+    template_dict['frame_rate_multiplier'] = frame_rate_multiplier2
+
+
+@when('it has dropMode <drop_mode2>')
+def when_drop_mode2(drop_mode2, template_dict):
+    template_dict['drop_mode'] = drop_mode2
+
+
+@when('it has markerMode <marker_mode2>')
+def when_marker_mode2(marker_mode2, template_dict):
+    template_dict['marker_mode'] = marker_mode2
+
+
+@when('it has sequence number <doc2_seqnum>')
+def when_doc2_has_seqnum(doc2_seqnum, template_dict):
+    template_dict['sequence_num'] = doc2_seqnum
+
+
+@then('adding doc2 to the sequence results in an error')
+def then_adding_doc2_error(doc_list, template_file, template_dict):
+    xml_file = template_file.render(template_dict)
+    document = EBUTT3Document.create_from_xml(xml_file)
+    sequence = EBUTT3DocumentSequence.create_from_document(doc_list[0])
+    with pytest.raises(Exception):
+        sequence.add_document(document)
+
+
+@then('adding doc2 to the sequence does not raise any error')
+def then_adding_doc2_success(doc_list, template_file, template_dict):
+    xml_file = template_file.render(template_dict)
+    document = EBUTT3Document.create_from_xml(xml_file)
+    sequence = EBUTT3DocumentSequence.create_from_document(doc_list[0])
+    sequence.add_document(document)


### PR DESCRIPTION
Test for R11 : Every document in a sequence shall have an identical timing model as defined by using the same values for the `ttp:timeBase` and `ttp:clockMode` attributes. (Note issue to add `frameRate`, `frameRateMultiplier` and `dropMode` to this attribute set)

Fix #183