### PR TITLE
delayTimingType (R68) tests + fix type regex

### DIFF
--- a/ebu_tt_live/xsd1.1/ebutt_datatypes.xsd
+++ b/ebu_tt_live/xsd1.1/ebutt_datatypes.xsd
@@ -95,7 +95,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="authoringDelayType">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="[+-]?[0-9]+(\.[0-9]+)?(h|m|s|ms)"/>
+			<xs:pattern value="[+-]?[0-9]+(\.[0-9]+)?(h|ms|s|m)"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="limitedClockTimingType">

--- a/testing/SPEC-CONFORMANCE.md
+++ b/testing/SPEC-CONFORMANCE.md
@@ -74,7 +74,7 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 |R65|3.2.2.5|`p` `end` attribute: If the timebase is "clock" the type shall be `ebuttdt:clockTimingType`. |`bdd/features/validation/timeBase\_timeformat\_constraints.feature` `(In)valid times according to timeBase in p`|
 |R66|3.2.2.6.1|Each distinctly identified facet shall have a separate `facet` element, where facets are identified by combination of the text content and the link attribute.| |
 |R67|3.2.2.6.1|Elements shall NOT contain more than one `facet` element referring to the same term.| |
-|R68|3.3.1| `ebuttdt:delayTimingType` The content shall be constrained to a signed (positive or negative) number with an optional decimal fraction, followed by a time metric being one of: "h" (hours), "m" (minutes), "s" (seconds), "ms" (milliseconds).| |
+|R68|3.3.1| `ebuttdt:delayTimingType` The content shall be constrained to a signed (positive or negative) number with an optional decimal fraction, followed by a time metric being one of: "h" (hours), "m" (minutes), "s" (seconds), "ms" (milliseconds).|`bdd/features/delayTimingType.feature` `(In)valid delayTimingType format`|
 | | **Tech3350 v1.1**| | |
 |R69|3|If `ttp:timeBase="smpte"` then the time expression of `begin` and `end`  SHALL have the format hh:mm:ss:ff||
 |R70|3|If `ttp:timeBase="media"`` then the time expression of `begin` and `end` attributes SHALL have one of the following formats: <ul><li>hh:mm:ss followed by an optional decimal fraction (full-clock value). The number of hours SHALL NOT be restricted.</li><li>non-negative number followed by an optional decimal fraction followed by one of the symbols h, m, s, ms (time-count value)</li></ul>|`bdd/features/validation/timeBase\_timeformat\_constraints.feature`|

--- a/testing/bdd/features/validation/delayTimingType.feature
+++ b/testing/bdd/features/validation/delayTimingType.feature
@@ -1,0 +1,29 @@
+@validation @xsd
+Feature: delayTimingType (used by attribute ebuttm:authoringDelay).
+  delayTimingType is constrained to a signed (positive or negative) number with an optional decimal fraction, followed by a time metric being one of: "h" (hours), "m" (minutes), "s" (seconds),   "ms" (milliseconds).
+
+  # SPEC-CONFORMANCE: R68
+  Scenario: Invalid delayTimingType format
+    Given an xml file <xml_file>
+    When ebuttm:authoringDelay attribute has value <authoring_delay>
+    Then document is invalid
+
+    Examples:
+    | xml_file                | authoring_delay |
+    | delayTimingType.xml     | 01:00:00        |
+    | delayTimingType.xml     | 01:00:00:25     |
+    | delayTimingType.xml     | 125a            |
+
+
+  # SPEC-CONFORMANCE: R68
+  Scenario: Valid delayTimingType format
+    Given an xml file <xml_file>
+    When ebuttm:authoringDelay attribute has value <authoring_delay>
+    Then document is valid
+
+    Examples:
+    | xml_file                | authoring_delay |
+    | delayTimingType.xml     | -5h             |
+    | delayTimingType.xml     | 1.5m            |
+    | delayTimingType.xml     | 125s            |
+    | delayTimingType.xml     | -5.4ms          |

--- a/testing/bdd/templates/delayTimingType.xml
+++ b/testing/bdd/templates/delayTimingType.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<tt:tt
+        ebuttp:sequenceIdentifier="1"
+        ebuttp:sequenceNumber="1"
+        ttp:clockMode="local"
+        ttp:timeBase="clock"
+        xml:lang="en-GB"
+{% if authoring_delay %}
+  {% if authoring_delay == "*?Empty?*" %}
+        ebuttm:authoringDelay=""
+  {% else %}
+        ebuttm:authoringDelay="{{authoring_delay}}"
+  {% endif %}
+{% endif %}
+        xmlns:ebuttm="urn:ebu:tt:metadata"
+        xmlns:ebuttp="urn:ebu:tt:parameters"
+        xmlns:tt="http://www.w3.org/ns/ttml"
+        xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <tt:head>
+    <tt:metadata>
+      <ebuttm:documentMetadata/>
+    </tt:metadata>
+    <tt:styling>
+      <tt:style xml:id="ID001"/>
+    </tt:styling>
+    <tt:layout/>
+  </tt:head>
+  <tt:body>
+    <tt:div>
+      <tt:p xml:id="ID005">
+        <tt:span>Some example text...</tt:span>
+        <tt:br/>
+        <tt:span>And another line</tt:span>
+      </tt:p>
+    </tt:div>
+  </tt:body>
+</tt:tt>

--- a/testing/bdd/test_delayTimingType.py
+++ b/testing/bdd/test_delayTimingType.py
@@ -1,0 +1,9 @@
+from pytest_bdd import when, scenarios
+
+
+scenarios('features/validation/delayTimingType.feature')
+
+
+@when('ebuttm:authoringDelay attribute has value <authoring_delay>')
+def when_authoring_delay(authoring_delay, template_dict):
+    template_dict['authoring_delay'] = authoring_delay


### PR DESCRIPTION
Test delayTimingType is well restricted to its format (R68).

Fix #193