### PR TITLE
test R9 : sequence numbers in a sequence shall increase over time

### DIFF
--- a/ebu_tt_live/documents/test/test_ebutt3sequence.py
+++ b/ebu_tt_live/documents/test/test_ebutt3sequence.py
@@ -82,3 +82,8 @@ class TestEBUTT3Sequence(TestCase):
 
         # We expect document2 to erase document3
         # TODO: Finish these on this unittesting level
+
+    # SPEC-CONFORMANCE : R9
+    def test_increasing_sequence_number(self):
+        self.assertGreater(self.document2.sequence_number, self.document1.sequence_number)
+        self.assertGreater(self.document3.sequence_number, self.document2.sequence_number)

--- a/testing/SPEC-CONFORMANCE.md
+++ b/testing/SPEC-CONFORMANCE.md
@@ -15,7 +15,7 @@ The conformance requirements for EBU-TT Part 3 derive from the specification its
 | R6|2.2 |the sequence identifier shall be present within every document|`bdd/features/validation/sequence\_id\_num.feature` `(In)valid Sequence head attributes`|
 | R7|2.2 |Documents with the same sequence identifier shall contain a sequence number.|`bdd/features/validation/sequence\_id\_num.feature` `(In)valid Sequence head attributes`|
 | R8|2.2 |Every distinct document with the same sequence identifier shall have a different sequence number.| |
-| R9|2.2 |Sequence numbers shall increase with the passage of time for each new document that is made available.| |
+| R9|2.2 |Sequence numbers shall increase with the passage of time for each new document that is made available.|`../ebu\_tt\_live/documents/test/test\_ebutt3sequence.py` `test\_increasing\_sequence\_number`|
 |R10|2.2 |Every document in a sequence shall be valid and self-contained.| |
 |R11|2.2 |Every document in a sequence shall have an identical timing model as defined by using the same values for the `ttp:timeBase` and `ttp:clockMode` attributes. (Note issue to add `frameRate`, `frameRateMultiplier` and `dropMode` to this attribute set)| |
 |R12|2.2 |A passive node shall NOT modify input sequences and shall only emit sequences that are identical (including the sequence numbers) to the input sequence(s)| |


### PR DESCRIPTION
I did not write a BDD test for this one as it was really easy to unit tests directly in the sequences tests. I think it is better this way, it avoids creating a new feature file and a new test file (a template would not even be used here). Moreover as it is a responsibility of the EBUTT3DocumentSequence class to handle sequence numbers, it seems logical to have a unit test for this one.

Fix #199