### PR TITLE
Document direct and web socket carriage mechanisms

### DIFF
--- a/docs/source/configurator.rst
+++ b/docs/source/configurator.rst
@@ -118,7 +118,7 @@ Node type dependent options for [nodeN] : ::
 Output carriage type dependent options for "carriage": ::
 
    type="direct"
-   └─id : id of the pipe to write to, default "default"
+   └─id : id of the 'pipe' to write to, default "default"
 
    type="filesystem"
    └─folder : The output folder/directory. Folder is created if it does not exist. Existing files are overwritten, default "./export"

--- a/docs/source/direct_carriage_mechanism.rst
+++ b/docs/source/direct_carriage_mechanism.rst
@@ -1,0 +1,6 @@
+Direct Carriage Mechanism
+=============================
+
+The direct carriage mechanism copies documents in memory via a named "pipe" from one node to another node. When configuring nodes to use the direct carriage mechanism the node emitting a document must specify the same pipe name as the node receiving that document.
+
+This carriage mechanism facilitates efficient chaining of nodes that perform sequential processing to the same content without having to use the network stack or local storage, however it requires the nodes to be hosted in the same process running on the same machine.

--- a/docs/source/direct_carriage_mechanism.rst
+++ b/docs/source/direct_carriage_mechanism.rst
@@ -1,6 +1,10 @@
 Direct Carriage Mechanism
 =============================
 
-The direct carriage mechanism copies documents in memory via a named "pipe" from one node to another node. When configuring nodes to use the direct carriage mechanism the node emitting a document must specify the same pipe name as the node receiving that document.
+The direct carriage mechanism copies documents in memory via a named "pipe" [#]_ from one node to another node. When configuring nodes to use the direct carriage mechanism the node emitting a document must specify the same pipe name as the node receiving that document.
 
 This carriage mechanism facilitates efficient chaining of nodes that perform sequential processing to the same content without having to use the network stack or local storage, however it requires the nodes to be hosted in the same process running on the same machine.
+
+.. rubric:: Footnotes
+
+.. [#] This is similar in concept to a UNIX pipe but completely unrelated in the implementation.

--- a/docs/source/ebu_tt_live.carriage.rst
+++ b/docs/source/ebu_tt_live.carriage.rst
@@ -33,14 +33,6 @@ carriage Package
     :undoc-members:
     :show-inheritance:
 
-:mod:`forwarder_carriage` Module
---------------------------------
-
-.. automodule:: ebu_tt_live.carriage.forwarder_carriage
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 :mod:`websocket` Module
 -----------------------
 

--- a/docs/source/nodes_and_carriage_mechanisms.rst
+++ b/docs/source/nodes_and_carriage_mechanisms.rst
@@ -7,3 +7,6 @@ Nodes and Carriage Mechanisms
 
    .. toctree::
       filesystem_carriage_mechanism
+      websocket_carriage_mechanism
+      direct_carriage_mechanism
+      

--- a/docs/source/websocket_carriage_mechanism.rst
+++ b/docs/source/websocket_carriage_mechanism.rst
@@ -1,0 +1,27 @@
+WebSocket Carriage Mechanism
+=============================
+
+The WebSocket carriage mechanism writes produced documents to WebSocket connections and consumes documents from WebSocket connections. This is conformant to the EBU-TT Live WebSocket Carriage Mechanism specification, using the URL form: ::
+
+	ws://[host]:[port]:[sequenceId]/[publish | subscribe]
+
+There are two ways to make a connection between node A and node B where documents of sequence "Sequence1" flow from A to B.
+
+1. Node A makes a /publish connection, for example: ::
+
+	ws://1.2.3.4:9000/Sequence1/publish
+
+2. Node B makes a /subscribe connection, for example : ::
+
+	ws://1.2.3.4/9001/Sequence1/subscribe
+
+If the sequence identifier contains a character that is reserved for use in URLs then it must be percent encoded exactly once before inserting into the URL. For example a sequence id "abc/def" becomes "abc%2Fdef" before inserting into the URL.
+
+Error handling
+--------------
+
+The expected documents are those that have the correct sequence number and flow from the emitter to the receiver. As per the specification, any unexpected data will cause the connection to be closed. These include:
+
+* Any data received by the emitter, since this reverse flow of data is unexpected.
+* Any document with a non-matching sequence identifier
+* Any data that is not a valid document


### PR DESCRIPTION
Fix #322:

* Add documentation of the direct carriage mechanism
* Add documentation of the WebSocket carriage mechanism

Also fix the build error caused by the reference to forwarder-carriage,
which no longer exists.