### PR TITLE
#308 issue system test bits

### DIFF
--- a/testing/bdd/features/config/websocket_carriage_config.feature
+++ b/testing/bdd/features/config/websocket_carriage_config.feature
@@ -4,11 +4,12 @@ Feature: Configuration of websocket carriage
 
   Examples:
   | config_file                    | xml_file            | sequence_identifier | time_base |
-  | websocket_carriage_config.json | sequence_if_num.xml | test                | media     |
+  | websocket_carriage_config.json | sequence_id_num.xml | test                | media     |
 
+  @skip
   Scenario: Get parts of sequence
     Given an xml file <xml_file>
-    And a settings file <settings_file>
+    And a config file <config_file>
     And a sequence <sequence_identifier> with timeBase <time_base>
     When a free port has been found
     And the producer listens on the port
@@ -18,5 +19,5 @@ Feature: Configuration of websocket carriage
     Then transmission should be successful
 
     Examples:
-    | sequence_number_1 | sequence_number_2 | client_url_path |
-    |                   |                   |                 |
+    | sequence_number_1 | sequence_number_2 | client_url_path         |
+    | 1                 | 2                 | TestSequence1/subscribe |

--- a/testing/bdd/templates/websocket_carriage_config.json
+++ b/testing/bdd/templates/websocket_carriage_config.json
@@ -19,8 +19,8 @@
         "carriage": {
           "type": "websocket",
           "connect": [
-            "ws://localhost:{{ephemeral_port}}/TestSequence1/subscribe"
-            ]
+            "ws://localhost:{{ephemeral_port}}/{{client_url_path}}"
+          ]
         }
       }
     }

--- a/testing/bdd/test_websocket_carriage_config.py
+++ b/testing/bdd/test_websocket_carriage_config.py
@@ -1,0 +1,19 @@
+
+from pytest_bdd import scenarios, given, when
+import socket
+
+
+scenarios('features/config/websocket_carriage_config.feature')
+
+
+@given('a config file <config_file>')
+def given_a_config_file(config_file):
+    pass
+
+
+@when('a free port has been found')
+def when_an_ephemeral_port_is_found(template__dict):
+    sock = socket.socket()
+    sock.bind(('', 0))
+    template__dict['ephemeral_port'] = sock.getsockname()[1]
+    sock.close()


### PR DESCRIPTION
this is currently skipped.

[additional notes added by @nigelmegitt later]

Partial implementation to support testing of WebSocket, not very closely tied to #308, but worth keeping. The problem here is that in the test framework if we run a reactor we have no way to get control back and stop it. This will take further work.