### PR TITLE
Typo of timing_end_limt to timing_end_limit

### DIFF
--- a/ebu_tt_live/bindings/validation/timing.py
+++ b/ebu_tt_live/bindings/validation/timing.py
@@ -50,7 +50,7 @@ class TimingValidationMixin(object):
 
     def _pre_assign_end(self, proposed_end):
         self._semantic_dataset['timing_end_stack'].append(proposed_end)
-        self._semantic_dataset['timing_end_limit'] = max(self._semantic_dataset.get('timing_end_limt', timedelta()), proposed_end)
+        self._semantic_dataset['timing_end_limit'] = max(self._semantic_dataset.get('timing_end_limit', timedelta()), proposed_end)
         self._computed_end_time = proposed_end
 
     def _pre_calculate_end(self):


### PR DESCRIPTION
Corrected the typo of `timing_end_limt` to `timing_end_limt` with the missing i.

No impact on this change since nothing referenced the misspelling. 

Fixes #404 