### PR TITLE
Use slack auto sign-up page

### DIFF
--- a/docs/build/index.html
+++ b/docs/build/index.html
@@ -73,29 +73,29 @@ header {
 
    <body>
    <header>
-         <a href="https://tech.ebu.ch/home"><img src="img/ebu-logo.png" alt="EBU logo"></a>
+         <a href="https://tech.ebu.ch/home" target="_blank" rel="noopener"><img src="img/ebu-logo.png" alt="EBU logo"></a>
    </header>
       <h1 class="title">EBU-TT Live Interoperability Toolkit</h3>
       <h2>Goals</h2>
-      <p>1. Validate the <a href="https://tech.ebu.ch/publications/tech3370">EBU-TT Part 3 Live</a> specification.</p>
+      <p>1. Validate the <a href="https://tech.ebu.ch/publications/tech3370" target="_blank" rel="noopener">EBU-TT Part 3 Live</a> specification.</p>
       <p>2. Provide a set of resources to help anyone making equipment or software using EBU-TT Part 3.</p>
       <h2>What is it?</h2>
       <p>The interoperability toolkit is a set of components, mostly written in Python (to be easy-ish to read) that can create EBU-TT Live documents (and sequences), transfer them from one Node to another using Carriage Mechanisms (currently WebSocket and the file system), validate them, and allow them to be viewed.</p>
       <p>If you are writing code to produce live subtitles in EBU-TT Live, you should try plugging it into the <i>consumer</i> to validate the sequences you make. If you are writing code to consume live subtitles, you should try using the <i>producer</i> to generate test data.</p>
       <h2>The Project</h2>
-      <p>This is an open source project hosted by <a href="https://tech.ebu.ch/home">EBU</a> on GitHub, using Travis-CI for continuous integration and coveralls for code test coverage. The license is BSD3.</p>
-      <p>This is an activity of the EBU <a href="https://tech.ebu.ch/subtitling">Subtitles in XML</a> group.</p>
-      <p>You can find details about the project, including details of how to contribute, on its <a href="https://github.com/ebu/ebu-tt-live-toolkit/">github page</a>.</p>
-      <p>For discussion of issues etc we have a Slack team - <a href="mailto:subtitling@ebu.ch?subject=EBU-TT-LIT%20Slack%20Invitation%20Request">request an invitation to sign up</a>.</p>
+      <p>This is an open source project hosted by <a href="https://tech.ebu.ch/home" target="_blank" rel="noopener">EBU</a> on GitHub, using Travis-CI for continuous integration and coveralls for code test coverage. The license is BSD3.</p>
+      <p>This is an activity of the EBU <a href="https://tech.ebu.ch/subtitling" target="_blank" rel="noopener">Subtitles in XML</a> group.</p>
+      <p>You can find details about the project, including details of how to contribute, on its <a href="https://github.com/ebu/ebu-tt-live-toolkit/" target="_blank" rel="noreferrer noopener">github page</a>.</p>
+      <p>For discussion of issues etc we have a Slack team - <a href="https://slack-invite.ebu.io/tt-lit/" target="_blank" rel="noreferrer noopener">request an invitation to sign up</a>.</p>
       <h3>Quick links</h3>
       <p>
-         <span class="q"><a href="html/index.html">documentation</a></span>
+         <span class="q"><a href="html/index.html" target="_self" rel="noopener">documentation</a></span>
          <span class="b"> </span>
-         <span class="q"><a href="https://github.com/ebu/ebu-tt-live-toolkit/">repository</a></span>
+         <span class="q"><a href="https://github.com/ebu/ebu-tt-live-toolkit/" target="_blank" rel="noreferrer noopener">repository</a></span>
          <span class="b"> </span>
-         <span class="q"><a href="https://tech.ebu.ch/publications/tech3370">specification</a></span>
+         <span class="q"><a href="https://tech.ebu.ch/publications/tech3370" target="_blank" rel="noopener">specification</a></span>
          <span class="b"> </span>
-         <span class="q"><a href="https://ebu-tt-lit.slack.com">discussion</a></span>
+         <span class="q"><a href="https://ebu-tt-lit.slack.com" target="_blank" rel="noreferrer noopener">discussion</a></span>
       </p>
       <footer>
       </footer>

--- a/docs/build/index.html
+++ b/docs/build/index.html
@@ -83,7 +83,7 @@ header {
       <p>The interoperability toolkit is a set of components, mostly written in Python (to be easy-ish to read) that can create EBU-TT Live documents (and sequences), transfer them from one Node to another using Carriage Mechanisms (currently WebSocket and the file system), validate them, and allow them to be viewed.</p>
       <p>If you are writing code to produce live subtitles in EBU-TT Live, you should try plugging it into the <i>consumer</i> to validate the sequences you make. If you are writing code to consume live subtitles, you should try using the <i>producer</i> to generate test data.</p>
       <h2>The Project</h2>
-      <p>This is an open source project hosted by <a href="https://tech.ebu.ch/home" target="_blank" rel="noopener">EBU</a> on GitHub, using Travis-CI for continuous integration and coveralls for code test coverage. The license is BSD3.</p>
+      <p>This is an open source project hosted by the <a href="https://tech.ebu.ch/home" target="_blank" rel="noopener">EBU</a> on GitHub, using Travis-CI for continuous integration and coveralls for code test coverage. The license is BSD3.</p>
       <p>This is an activity of the EBU <a href="https://tech.ebu.ch/subtitling" target="_blank" rel="noopener">Subtitles in XML</a> group.</p>
       <p>You can find details about the project, including details of how to contribute, on its <a href="https://github.com/ebu/ebu-tt-live-toolkit/" target="_blank" rel="noreferrer noopener">github page</a>.</p>
       <p>For discussion of issues etc we have a Slack team - <a href="https://slack-invite.ebu.io/tt-lit/" target="_blank" rel="noreferrer noopener">request an invitation to sign up</a>.</p>

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description="EBU-TT Part 3 library implementing Specification EBU-3370",
     install_requires=[
         "PyXB",
-        "ipdb",  # This will eventually be removed from here
+        "ipdb>=0.10.1,<0.10.3",  # This will eventually be removed from here
         "configobj",
         "pyyaml",
         "twisted",


### PR DESCRIPTION
* add `target` and `rel` attributes to all links in home page
* fix #426 by linking to slack auto-invite page instead of mailto link.