### PR TITLE
Serve ui pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs uiclean uibuild template initnpm
+.PHONY: docs uiclean uibuild template initnpm uicopy
 
 all: init ui
 	
@@ -25,8 +25,8 @@ bindings:
 ui: uiclean uibuild
 	
 uiclean:
-ifneq ($(wildcard docs/build/ui/.),)
-	rm -r docs/build/ui
+ifneq ("$(wildcard docs/build/ui/.)","")
+	rm -R docs/build/ui
 endif
 	
 uibuild: template uicopy
@@ -36,9 +36,7 @@ template: initnpm
 	node_modules/nunjucks/bin/precompile ebu_tt_live/ui/user_input_producer/template/live_message_template.xml > ebu_tt_live/ui/user_input_producer/template/live_message_template.js
 
 uicopy:
-ifeq ($(wildcard docs/build/ui/.),)
-	mkdir docs/build/ui
-endif
+	mkdir -p docs/build/ui
 	cp -R ebu_tt_live/ui/user_input_producer docs/build/ui/
 	cp -R ebu_tt_live/ui/test docs/build/ui/
 	cp -R ebu_tt_live/ui/assets docs/build/ui/user_input_producer/

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
-.PHONY: docs
+.PHONY: docs uiclean uibuild template initnpm
 
+all: init ui
+	
 init:
 	pip install --upgrade -r requirements.txt
 	pyxbgen --binding-root=./ebu_tt_live/bindings -m __init__ --schema-root=./ebu_tt_live/xsd/ -r -u ebutt_all.xsd
-ifeq ("$(wildcard node_modules)","")
-	npm install nunjucks
-else 
-	npm update nunjucks
-endif
-	node_modules/nunjucks/bin/precompile ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.xml > ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.js
-	node_modules/nunjucks/bin/precompile ebu_tt_live/ui/user_input_producer/template/live_message_template.xml > ebu_tt_live/ui/user_input_producer/template/live_message_template.js
 
 initnpm:
 ifeq ("$(wildcard node_modules)","")
@@ -17,9 +12,6 @@ ifeq ("$(wildcard node_modules)","")
 else 
 	npm update nunjucks
 endif
-
-template:
-	node_modules/nunjucks/bin/precompile ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.xml > ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.js
 
 test:
 	python setup.py test
@@ -29,3 +21,26 @@ docs:
 
 bindings:
 	pyxbgen --binding-root=./ebu_tt_live/bindings -m __init__ --schema-root=./ebu_tt_live/xsd/ -r -u ebutt_all.xsd
+
+ui: uiclean uibuild
+	
+uiclean:
+ifneq ($(wildcard docs/build/ui/.),)
+	rm -r docs/build/ui
+endif
+	
+uibuild: template uicopy
+	
+template: initnpm
+	node_modules/nunjucks/bin/precompile ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.xml > ebu_tt_live/ui/user_input_producer/template/user_input_producer_template.js
+	node_modules/nunjucks/bin/precompile ebu_tt_live/ui/user_input_producer/template/live_message_template.xml > ebu_tt_live/ui/user_input_producer/template/live_message_template.js
+
+uicopy:
+ifeq ($(wildcard docs/build/ui/.),)
+	mkdir docs/build/ui
+endif
+	cp -R ebu_tt_live/ui/user_input_producer docs/build/ui/
+	cp -R ebu_tt_live/ui/test docs/build/ui/
+	cp -R ebu_tt_live/ui/assets docs/build/ui/user_input_producer/
+	cp -R ebu_tt_live/ui/assets docs/build/ui/test/
+		

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -22,7 +22,8 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
-that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html`` in your
+that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html``
+`current release pre-built page <../ui/test>`_ in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
 also change the identifier for the sequence. The documents should appear in the
@@ -56,7 +57,8 @@ Distributor or a Handover Manager Node. First, with your virtual environment
 activated and the code built, start one, with a command line such as  ``ebu-run
 --admin.conf ebu_tt_live/examples/config/user_input_producer_consumer.json`` -
 this one runs a simple consumer. Then, in your browser, open
-``docs/build/ui/user_input_producer/index.html`` and click
+``docs/build/ui/user_input_producer/index.html`` or the 
+`current release pre-built page <../ui/user_input_producer>`_ and click
 'Connect'. Select the sending mode (manual, scheduled or asynchronous). You
 should see the documents arriving in the command line window where the simple
 consumer is listening. See detailed instructions here:

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -23,7 +23,7 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
 that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html``
-`current release pre-built page <../ui/test>`_ in your
+or the `current release pre-built page <../ui/test>`_ in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
 also change the identifier for the sequence. The documents should appear in the

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -23,7 +23,7 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
 that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html``
-or the `current release pre-built page <../ui/test/index.html>`_ in your
+or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/test/>`_ in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
 also change the identifier for the sequence. The documents should appear in the
@@ -58,7 +58,7 @@ activated and the code built, start one, with a command line such as  ``ebu-run
 --admin.conf ebu_tt_live/examples/config/user_input_producer_consumer.json`` -
 this one runs a simple consumer. Then, in your browser, open
 ``docs/build/ui/user_input_producer/index.html`` or the
-`current release pre-built page <../ui/user_input_producer/index.html>`_ and click
+`current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ and click
 'Connect'. Select the sending mode (manual, scheduled or asynchronous). You
 should see the documents arriving in the command line window where the simple
 consumer is listening. See detailed instructions here:

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -23,7 +23,7 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
 that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html``
-or the `current release pre-built page <../ui/test>`_ in your
+or the `current release pre-built page <../ui/test/index.html>`_ in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
 also change the identifier for the sequence. The documents should appear in the
@@ -57,8 +57,8 @@ Distributor or a Handover Manager Node. First, with your virtual environment
 activated and the code built, start one, with a command line such as  ``ebu-run
 --admin.conf ebu_tt_live/examples/config/user_input_producer_consumer.json`` -
 this one runs a simple consumer. Then, in your browser, open
-``docs/build/ui/user_input_producer/index.html`` or the 
-`current release pre-built page <../ui/user_input_producer>`_ and click
+``docs/build/ui/user_input_producer/index.html`` or the
+`current release pre-built page <../ui/user_input_producer/index.html>`_ and click
 'Connect'. Select the sending mode (manual, scheduled or asynchronous). You
 should see the documents arriving in the command line window where the simple
 consumer is listening. See detailed instructions here:
@@ -108,7 +108,7 @@ The times are modified such that all of the computed begin and end times within
 the document are increased by a non-negative fixed delay offset period. The
 Retiming Delay Node is primarily intended for delaying explicitly timed
 documents. Use ``ebu-run`` to start this script, for example ``ebu-run
---admin.conf=ebu_tt_live/examples/config/retiming_delay.json.`` 
+--admin.conf=ebu_tt_live/examples/config/retiming_delay.json.``
 
 EBU-TT-D Encoder
 ----------------

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -22,7 +22,7 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
-that. After you launch the Simple Producer, open ``test.html`` in your
+that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html`` in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
 also change the identifier for the sequence. The documents should appear in the
@@ -56,7 +56,7 @@ Distributor or a Handover Manager Node. First, with your virtual environment
 activated and the code built, start one, with a command line such as  ``ebu-run
 --admin.conf ebu_tt_live/examples/config/user_input_producer_consumer.json`` -
 this one runs a simple consumer. Then, in your browser, open
-``ebu_tt_live/ui/user_input_producer/user_input_producer.html`` and click
+``docs/build/ui/user_input_producer/index.html`` and click
 'Connect'. Select the sending mode (manual, scheduled or asynchronous). You
 should see the documents arriving in the command line window where the simple
 consumer is listening. See detailed instructions here:

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -22,7 +22,7 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
-that. After you launch the Simple Producer, open ``docs/build/ui/test/index.html``
+that. After you launch the Simple Producer, open `docs/build/ui/test/index.html <../ui/test/index.html>`_ 
 or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/test/>`_ in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
@@ -57,7 +57,7 @@ Distributor or a Handover Manager Node. First, with your virtual environment
 activated and the code built, start one, with a command line such as  ``ebu-run
 --admin.conf ebu_tt_live/examples/config/user_input_producer_consumer.json`` -
 this one runs a simple consumer. Then, in your browser, open
-``docs/build/ui/user_input_producer/index.html`` or the
+`docs/build/ui/user_input_producer/index.html <../ui/user_input_producer/index.html>`_ or the
 `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ and click
 'Connect'. Select the sending mode (manual, scheduled or asynchronous). You
 should see the documents arriving in the command line window where the simple

--- a/docs/source/user_input_producer.rst
+++ b/docs/source/user_input_producer.rst
@@ -16,7 +16,7 @@ ebu_tt_live/examples/config/user_input_producer_consumer.json`` will run the
 simplest user-input-consumer script listening for a connection on the local host
 port 9001. Then open the
 ``ebu_tt_live/docs/build/ui/user_input_producer/index.html`` file in your
-browser.
+browser, or open the `current release pre-built page <../ui/user_input_producer>`_.
 
 If you have no configured sequences or you need to create a new one, click
 "Create a new sequence", enter the sequence number, what time base and clock
@@ -61,7 +61,7 @@ transport mechanism, follow these steps:
 
 * Start the Handover Manager: ``ebu-run --admin.conf=ebu_tt_live/examples/config/user_input_producer_handover.json``
 
-* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` in multiple browser tabs/windows.
+* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` or the `current release pre-built page <../ui/user_input_producer>`_ in multiple browser tabs/windows.
 
 * In each instance of the UIP, create a sequence with a different sequence identifier but with identical authors group identifier. If you use the default configuration, this is "TestGroup1".
 
@@ -84,7 +84,7 @@ in the Control Request field.
 
 .. note:: More demo scenario examples :
 
-    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
+    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page or the `current release pre-built page <../ui/user_input_producer>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
 
 .. note:: Demo scenario examples that need some better documentation :
 

--- a/docs/source/user_input_producer.rst
+++ b/docs/source/user_input_producer.rst
@@ -15,7 +15,7 @@ listen for /publish requests - for example ``ebu-run --admin.conf
 ebu_tt_live/examples/config/user_input_producer_consumer.json`` will run the
 simplest user-input-consumer script listening for a connection on the local host
 port 9001. Then open the
-``ebu_tt_live/ui/user_input_producer/user_input_producer.html`` file in your
+``ebu_tt_live/docs/build/ui/user_input_producer/index.html`` file in your
 browser.
 
 If you have no configured sequences or you need to create a new one, click
@@ -61,7 +61,7 @@ transport mechanism, follow these steps:
 
 * Start the Handover Manager: ``ebu-run --admin.conf=ebu_tt_live/examples/config/user_input_producer_handover.json``
 
-* Create two (or more) instances of the User Input Producer by opening ``ebu_tt_live/ui/user_input_producer/user_input_producer.html`` in multiple browser tabs/windows.
+* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` in multiple browser tabs/windows.
 
 * In each instance of the UIP, create a sequence with a different sequence identifier but with identical authors group identifier. If you use the default configuration, this is "TestGroup1".
 
@@ -84,7 +84,7 @@ in the Control Request field.
 
 .. note:: More demo scenario examples :
 
-    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``ui/user_input_producer/user_input_producer.html`` page and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
+    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
 
 .. note:: Demo scenario examples that need some better documentation :
 

--- a/docs/source/user_input_producer.rst
+++ b/docs/source/user_input_producer.rst
@@ -16,7 +16,7 @@ ebu_tt_live/examples/config/user_input_producer_consumer.json`` will run the
 simplest user-input-consumer script listening for a connection on the local host
 port 9001. Then open the
 ``ebu_tt_live/docs/build/ui/user_input_producer/index.html`` file in your
-browser, or open the `current release pre-built page <../ui/user_input_producer/index.html>`_.
+browser, or open the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_.
 
 If you have no configured sequences or you need to create a new one, click
 "Create a new sequence", enter the sequence number, what time base and clock
@@ -61,7 +61,7 @@ transport mechanism, follow these steps:
 
 * Start the Handover Manager: ``ebu-run --admin.conf=ebu_tt_live/examples/config/user_input_producer_handover.json``
 
-* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` or the `current release pre-built page <../ui/user_input_producer/index.html>`_ in multiple browser tabs/windows.
+* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ in multiple browser tabs/windows.
 
 * In each instance of the UIP, create a sequence with a different sequence identifier but with identical authors group identifier. If you use the default configuration, this is "TestGroup1".
 
@@ -84,7 +84,7 @@ in the Control Request field.
 
 .. note:: More demo scenario examples :
 
-    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page or the `current release pre-built page <../ui/user_input_producer/index.html>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
+    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
 
 .. note:: Demo scenario examples that need some better documentation :
 

--- a/docs/source/user_input_producer.rst
+++ b/docs/source/user_input_producer.rst
@@ -15,7 +15,7 @@ listen for /publish requests - for example ``ebu-run --admin.conf
 ebu_tt_live/examples/config/user_input_producer_consumer.json`` will run the
 simplest user-input-consumer script listening for a connection on the local host
 port 9001. Then open the
-``ebu_tt_live/docs/build/ui/user_input_producer/index.html`` file in your
+`docs/build/ui/user_input_producer/index.html <../ui/user_input_producer/index.html>`_ file in your
 browser, or open the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_.
 
 If you have no configured sequences or you need to create a new one, click
@@ -61,7 +61,7 @@ transport mechanism, follow these steps:
 
 * Start the Handover Manager: ``ebu-run --admin.conf=ebu_tt_live/examples/config/user_input_producer_handover.json``
 
-* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ in multiple browser tabs/windows.
+* Create two (or more) instances of the User Input Producer by opening `docs/build/ui/user_input_producer/index.html <../ui/user_input_producer/index.html>`_ or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ in multiple browser tabs/windows.
 
 * In each instance of the UIP, create a sequence with a different sequence identifier but with identical authors group identifier. If you use the default configuration, this is "TestGroup1".
 
@@ -84,7 +84,7 @@ in the Control Request field.
 
 .. note:: More demo scenario examples :
 
-    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
+    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the `docs/build/ui/user_input_producer/index.html <../ui/user_input_producer/index.html>`_ page or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
 
 .. note:: Demo scenario examples that need some better documentation :
 

--- a/docs/source/user_input_producer.rst
+++ b/docs/source/user_input_producer.rst
@@ -16,7 +16,7 @@ ebu_tt_live/examples/config/user_input_producer_consumer.json`` will run the
 simplest user-input-consumer script listening for a connection on the local host
 port 9001. Then open the
 ``ebu_tt_live/docs/build/ui/user_input_producer/index.html`` file in your
-browser, or open the `current release pre-built page <../ui/user_input_producer>`_.
+browser, or open the `current release pre-built page <../ui/user_input_producer/index.html>`_.
 
 If you have no configured sequences or you need to create a new one, click
 "Create a new sequence", enter the sequence number, what time base and clock
@@ -61,7 +61,7 @@ transport mechanism, follow these steps:
 
 * Start the Handover Manager: ``ebu-run --admin.conf=ebu_tt_live/examples/config/user_input_producer_handover.json``
 
-* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` or the `current release pre-built page <../ui/user_input_producer>`_ in multiple browser tabs/windows.
+* Create two (or more) instances of the User Input Producer by opening ``docs/build/ui/user_input_producer/index.html`` or the `current release pre-built page <../ui/user_input_producer/index.html>`_ in multiple browser tabs/windows.
 
 * In each instance of the UIP, create a sequence with a different sequence identifier but with identical authors group identifier. If you use the default configuration, this is "TestGroup1".
 
@@ -84,7 +84,7 @@ in the Control Request field.
 
 .. note:: More demo scenario examples :
 
-    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page or the `current release pre-built page <../ui/user_input_producer>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
+    * Run ``ebu-run --admin.conf ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``. This configuration runs a distributor node and two consumers, one for TestSequence1 and the other for TestSequence2. Open the ``docs/build/ui/user_input_producer/index.html`` page or the `current release pre-built page <../ui/user_input_producer/index.html>`_ and create or select TestSequence1, and connect it to the distributor node via websocket (click "connect" button). When you send a document the consumer will log the new document. Open another user input web page and connect it with TestSequence2. The second consumer receives this document. Now documents can be sent by both web pages simultaneously and will be routed to the correct consumer by the Distributor node.
 
 .. note:: Demo scenario examples that need some better documentation :
 

--- a/ebu_tt_live/ui/test/index.html
+++ b/ebu_tt_live/ui/test/index.html
@@ -99,14 +99,14 @@
             ellog.scrollTop = 0;
          };
       </script>
-      <link rel="stylesheet" href="../assets/css/bootstrap.css" media="screen">
-      <link rel="stylesheet" href="../assets/css/custom.min.css" media="screen">
-      <link rel="stylesheet" href="../assets/css/main.css" media="screen">
-      <link rel="stylesheet" href="../assets/css/test-style.css" media="screen">
+      <link rel="stylesheet" href="assets/css/bootstrap.css" media="screen">
+      <link rel="stylesheet" href="assets/css/custom.min.css" media="screen">
+      <link rel="stylesheet" href="assets/css/main.css" media="screen">
+      <link rel="stylesheet" href="assets/css/test-style.css" media="screen">
    </head>
    <body>
      <div id="header">
-       <a href="https://tech.ebu.ch/home"><img src="../assets/img/ebu-logo-relaunch.png"/></a>
+       <a href="https://tech.ebu.ch/home"><img src="assets/img/ebu-logo-relaunch.png"/></a>
        <h1><a href="http://ebu.github.io/ebu-tt-live-toolkit/">EBU-TT Live Interoperability Toolkit</a></h1>
        <h3>This is the WebSocket Test document viewer.</h3>
        It subscribes to a sequence of Part 3 documents on a WebSocket connection and displays each document as it arrives.

--- a/ebu_tt_live/ui/user_input_producer/index.html
+++ b/ebu_tt_live/ui/user_input_producer/index.html
@@ -8,16 +8,16 @@
       <script src="moment.js"></script>
       <script src="nunjucks.js"></script>
       <script src="uip.js"></script>
-      <link rel="stylesheet" href="../assets/css/bootstrap.css" media="screen">
-      <link rel="stylesheet" href="../assets/css/custom.min.css" media="screen">
-      <link rel="stylesheet" href="../assets/css/main.css" media="screen">
+      <link rel="stylesheet" href="assets/css/bootstrap.css" media="screen">
+      <link rel="stylesheet" href="assets/css/custom.min.css" media="screen">
+      <link rel="stylesheet" href="assets/css/main.css" media="screen">
 
    </head>
    <body>
 
       <div class="wrapper">
          <div id="header">
-            <div class="left"><a href="https://tech.ebu.ch/home"><img src="../assets/img/ebu-logo-relaunch.png"/></a></div>
+            <div class="left"><a href="https://tech.ebu.ch/home"><img src="assets/img/ebu-logo-relaunch.png"/></a></div>
             <div class="right">
                <h1><a href="http://ebu.github.io/ebu-tt-live-toolkit/">EBU-TT Live Interoperability Toolkit</a></h1>
                <h3>This is the User Input Producer (UIP).</h3>


### PR DESCRIPTION
Fixes #450.

* Makefile now cleans UI components from `build/docs/ui` and then makes the templates and copies all the components into place (`make ui`)
* Pages are all called `index.html` for default serving.
* Relative links to `../assets/*` replaced by forward links to `assets/*` - the contents of `assets` exists once in the repo and is duplicated into the relevant places by the Makefile
* Documentation updated to have fixed links and to link to the versions that will be served by GitHub Pages.

This breaks existing links to `ebu-tt-live/ui/user_input_producer/user-input-producer.html` in two ways:
1. The forward links to the assets no longer work since the `assets` folder is not in the place it is expecting - solution is to open the built versions instead.
2. The file no longer exists with that name - it is called `index.html` instead.
