### PR TITLE
Use `hyperlink.URL` from before when they broke it

### DIFF
--- a/ebu_tt_live/twisted/websocket.py
+++ b/ebu_tt_live/twisted/websocket.py
@@ -3,7 +3,7 @@ from autobahn.twisted.websocket import WebSocketClientProtocol, WebSocketServerF
     listenWS, WebSocketClientFactory, connectWS
 
 from twisted.internet import interfaces, reactor
-from twisted.python import url as twisted_url
+from hyperlink import URL
 from zope.interface import implementer
 from logging import getLogger
 import json
@@ -16,7 +16,6 @@ from .base import IBroadcaster
 
 
 log = getLogger(__name__)
-
 
 class UserInputServerProtocol(WebSocketServerProtocol):
     def onOpen(self):
@@ -102,7 +101,7 @@ class EBUWebsocketProtocolMixin(object):
     def _parse_path(self, full_url):
         if not isinstance(full_url, six.text_type):
             full_url = six.text_type(full_url)
-        result = twisted_url.URL.fromText(full_url).asIRI()
+        result = URL.fromText(full_url).to_iri()
         sequence_identifier, action = result.path
         return sequence_identifier, action
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         "nltk",
         "sortedcontainers",
         "configman",
-        "six"
+        "six",
+        "hyperlink<17.2.0"  # This should be removed if https://github.com/python-hyper/hyperlink/issues/16 is fixed
     ],
     license="BSD3",
     packages=packages,


### PR DESCRIPTION
Fixes #452 for now.

* Twisted now just imports from hyperlink, so rather than depending on
this, go straight to hyperlink.URL
* It was broken in hyperlink 17.2.0 so require an earlier version.

Remove the earlier version requirement if/when the bug gets fixed.