### PR TITLE
Issue 454 encoder timebase on emit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,9 @@ gen
 # Generated bindings should not appear in the repo
 ebu_tt_live/bindings/raw
 
-# Test export files from file system carriage
+# Test and non-test export files from file system carriage
 test_export/
+export/
 
 # Node.js file
 node_modules/
@@ -127,3 +128,4 @@ docs/build/*
 
 # Mac OS X files
 .DS_Store
+

--- a/ebu_tt_live/examples/config/sproducer_resequencer_direct_ebuttd_encoder_fs.json
+++ b/ebu_tt_live/examples/config/sproducer_resequencer_direct_ebuttd_encoder_fs.json
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "node1": {
+      "id": "producer1",
+      "type": "simple-producer",
+      "show_time": true,
+      "sequence_identifier": "TestSequence1",
+      "output": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe1"
+        }
+      }
+    },
+    "node2": {
+      "id": "resequencer1",
+      "type": "resequencer",
+      "sequence_identifier": "ReSequenced1",
+      "segment_length": "5.0",
+      "input": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe1"
+        }
+      },
+      "output": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe2"
+        }
+      }
+    },
+    "node3": {
+      "id": "encoder1",
+      "type": "ebuttd-encoder",
+      "input": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe2"
+        }
+      },
+      "output": {
+        "carriage": {
+          "type": "filesystem"
+        }
+      }
+    }
+  }
+}

--- a/ebu_tt_live/examples/config/sproducer_retiming_fs.json
+++ b/ebu_tt_live/examples/config/sproducer_retiming_fs.json
@@ -1,0 +1,33 @@
+{
+  "nodes": {
+    "node1": {
+      "id": "producer1",
+      "type": "simple-producer",
+      "show_time": true,
+      "sequence_identifier": "TestSequence1",
+      "output": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe1"
+        }
+      }
+    },
+    "node2": {
+        "id": "retiming1",
+        "type": "retiming-delay",
+        "input": {
+          "carriage": {
+            "type": "direct",
+            "id": "pipe1"
+          }
+        },
+        "output": {
+          "carriage": {
+            "type": "filesystem"
+          }
+        },
+        "delay": 3,
+        "sequence_identifier": "RetimedSequence1"
+    }
+  }
+}

--- a/ebu_tt_live/node/encoder.py
+++ b/ebu_tt_live/node/encoder.py
@@ -41,4 +41,4 @@ class EBUTTDEncoder(AbstractCombinedNode):
             converted_doc = EBUTTDDocument.create_from_raw_binding(
                 self._ebuttd_converter.convert_document(document.binding)
             )
-            self.producer_carriage.emit_data(data=converted_doc, sequence_identifier='default', **kwargs)
+            self.producer_carriage.emit_data(data=converted_doc, sequence_identifier='default', time_base='media', **kwargs)

--- a/ebu_tt_live/node/encoder.py
+++ b/ebu_tt_live/node/encoder.py
@@ -41,4 +41,8 @@ class EBUTTDEncoder(AbstractCombinedNode):
             converted_doc = EBUTTDDocument.create_from_raw_binding(
                 self._ebuttd_converter.convert_document(document.binding)
             )
+            # Specify the time_base since the FilesystemProducerImpl can't derive it otherwise.
+            # Hard coded to 'media' because that's all that's permitted in EBU-TT-D. Alternative
+            # would be to extract it from the EBUTTDDocument but since it's the only permitted
+            # value that would be an unnecessary overhead...
             self.producer_carriage.emit_data(data=converted_doc, sequence_identifier='default', time_base='media', **kwargs)


### PR DESCRIPTION
Fixes #454 by specifying the `time_base` parameter when emitting from the Encoder node. `FilesystemProducerImpl.emit_data()` is then able to generate a suitable clock for the media timebase.

Hard coded to media timebase because that’s the only kind that’s permitted for EBU-TT-D documents. Arguably we should pass through whatever the document says, but I decided not to due to the pointless overhead. One day this will trip me up, possibly.