### PR TITLE
Issue 464 deduplicator before ebuttd encoding

### DIFF
--- a/ebu_tt_live/examples/config/sproducer_resequencer_deduplicator_direct_ebuttd_encoder_fs.json
+++ b/ebu_tt_live/examples/config/sproducer_resequencer_deduplicator_direct_ebuttd_encoder_fs.json
@@ -59,7 +59,8 @@
       "output": {
         "carriage": {
           "type": "filesystem",
-          "suppress_manifest": true
+          "suppress_manifest": true,
+          "message_filename_pattern": "ebuttd_{counter}.ebuttd.xml"
         }
       }
     }

--- a/ebu_tt_live/examples/config/sproducer_resequencer_deduplicator_direct_ebuttd_encoder_fs.json
+++ b/ebu_tt_live/examples/config/sproducer_resequencer_deduplicator_direct_ebuttd_encoder_fs.json
@@ -1,0 +1,67 @@
+{
+  "nodes": {
+    "node1": {
+      "id": "producer1",
+      "type": "simple-producer",
+      "show_time": true,
+      "sequence_identifier": "TestSequence1",
+      "output": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe1"
+        }
+      }
+    },
+    "node2": {
+      "id": "resequencer1",
+      "type": "resequencer",
+      "sequence_identifier": "ReSequenced1",
+      "segment_length": "5.0",
+      "input": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe1"
+        }
+      },
+      "output": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe2"
+        }
+      }
+    },
+    "node3": {
+      "id": "deduplicator1",
+      "type": "deduplicator",
+      "sequence_identifier": "Deduplicated1",
+      "input": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe2"
+        }
+      },
+      "output": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe3"
+        }
+      }
+    },
+    "node4": {
+      "id": "encoder1",
+      "type": "ebuttd-encoder",
+      "input": {
+        "carriage": {
+          "type": "direct",
+          "id": "pipe3"
+        }
+      },
+      "output": {
+        "carriage": {
+          "type": "filesystem",
+          "suppress_manifest": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix for #464. Should deduplicate resequenced output before EBU-TT-D
encoding, and make tidy EBU-TT-D.