### PR TITLE
Remove requirement for pytest-capturelog

### DIFF
--- a/ebu_tt_live/config/backend.py
+++ b/ebu_tt_live/config/backend.py
@@ -137,8 +137,6 @@ class TwistedBackend(BackendBase):
 
     def _ws_create_client_factories(self, connect, producer=None, consumer=None, proxy=None):
         factory_args = {}
-        if proxy:
-            factory_args.update({'host': proxy.host, 'port': proxy.port})
         for dst in connect:
             client_factory = self._websocket.BroadcastClientFactory(
                 url=dst.geturl(),
@@ -147,6 +145,10 @@ class TwistedBackend(BackendBase):
                 **factory_args
             )
             client_factory.protocol = self._websocket.BroadcastClientProtocol
+            if proxy:
+                proxy_dict = {u'host': proxy.host, u'port': proxy.port}
+                client_factory.proxy = proxy_dict
+
             client_factory.connect()
 
     def ws_backend_producer(self, custom_producer, listen=None, connect=None, proxy=None):

--- a/ebu_tt_live/config/backend.py
+++ b/ebu_tt_live/config/backend.py
@@ -145,9 +145,7 @@ class TwistedBackend(BackendBase):
                 **factory_args
             )
             client_factory.protocol = self._websocket.BroadcastClientProtocol
-            if proxy:
-                proxy_dict = {u'host': proxy.host, u'port': proxy.port}
-                client_factory.proxy = proxy_dict
+            client_factory.proxy = proxy
 
             client_factory.connect()
 

--- a/ebu_tt_live/config/carriage.py
+++ b/ebu_tt_live/config/carriage.py
@@ -2,7 +2,6 @@ from .common import ConfigurableComponent, Namespace
 from ebu_tt_live.carriage.direct import DirectCarriageImpl
 from ebu_tt_live.carriage.websocket import WebsocketProducerCarriage, WebsocketConsumerCarriage
 from ebu_tt_live.carriage import filesystem
-from ebu_tt_live.utils import HTTPProxyConfig
 from ebu_tt_live.strings import ERR_CONF_PROXY_CONF_VALUE, ERR_NO_SUCH_COMPONENT
 from ebu_tt_live.errors import ConfigurationError
 from ebu_tt_live.strings import CFG_FILENAME_PATTERN, CFG_MESSAGE_PATTERN
@@ -134,10 +133,7 @@ def parse_proxy_address(value):
     match = proxy_regex.match(value)
     if match:
         # Ignoring the protocol part for now as it is only a http proxy
-        result = HTTPProxyConfig(
-            host=match.group('host'),
-            port=int(match.group('port'))
-        )
+        result = {u'host': match.group('host'), u'port': int(match.group('port'))}
     elif value:
         # In this case something was provided that isn't a falsy value but the parsing failed.
         raise ConfigurationError(

--- a/ebu_tt_live/utils.py
+++ b/ebu_tt_live/utils.py
@@ -358,8 +358,6 @@ class AutoRegisteringABCMeta(abc.ABCMeta):
         instance = super(AutoRegisteringABCMeta, cls).__call__(*args, **kwargs)
         return instance
 
-HTTPProxyConfig = collections.namedtuple('HTTPProxyConfig', ['host', 'port'])
-
 
 # The following section is taken from https://github.com/django/django/blob/master/django/test/utils.py
 # This is a relatively simple XML comparator implementation based on Python's minidom library.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ sphinx-rtd-theme
 pytest-bdd
 pytest-cov
 pytest-mock
-pytest-capturelog
 pytest-twisted
 coverage
 pytest-runner


### PR DESCRIPTION
No longer needed because it has been merged into the core.

Fixes #477.