### PR TITLE
Resequencer: allow to immediately issue documents

### DIFF
--- a/docs/source/configurator.rst
+++ b/docs/source/configurator.rst
@@ -99,6 +99,7 @@ Node type dependent options for [nodeN] : ::
    ├─sequence_identifier : sequence identifier, default "re-sequencer"
    ├─segment_length : duration of each output segment in seconds, default 2
    ├─begin_output : ["immediate" (default) | {begin time} ] the time at which the first output segment should begin.
+   ├─init_document : File path to a document used to set initial parameters and afterwards start issuing documents (instead of awaiting the first received document), default None
    ├─discard : whether to discard content that has been encoded, default True
    └─clock
      └─type : ["local" (default) | "auto" | "clock"]

--- a/ebu_tt_live/config/node.py
+++ b/ebu_tt_live/config/node.py
@@ -102,6 +102,7 @@ class ReSequencer(ProducerMixin, ConsumerMixin, NodeBase):
     required_config.add_option('segment_length', default=2.0)
     required_config.clock = Namespace()
     required_config.clock.add_option('type', default='local', from_string_converter=get_clock)
+    required_config.add_option('init_document', default=None)
     required_config.add_option('discard', default=True)
     required_config.add_option(
         'begin_output',
@@ -128,6 +129,7 @@ class ReSequencer(ProducerMixin, ConsumerMixin, NodeBase):
         self.component = processing_node.ReSequencer(
             node_id=self.config.id,
             reference_clock=self._clock.component,
+            init_document=self.config.init_document,
             discard=self.config.discard,
             segment_length=self.config.segment_length,
             sequence_identifier=self.config.sequence_identifier

--- a/ebu_tt_live/node/consumer.py
+++ b/ebu_tt_live/node/consumer.py
@@ -76,7 +76,7 @@ class ReSequencer(AbstractProducerNode, SimpleConsumer):
     _expects = EBUTT3Document
     _provides = EBUTT3Document
 
-    def __init__(self, node_id, reference_clock, segment_length, discard, sequence_identifier,
+    def __init__(self, node_id, reference_clock, segment_length, init_document, discard, sequence_identifier,
                  consumer_carriage=None, producer_carriage=None, **kwargs):
         super(ReSequencer, self).__init__(
             node_id=node_id,
@@ -91,6 +91,20 @@ class ReSequencer(AbstractProducerNode, SimpleConsumer):
         self._segment_counter = 1
         self._sequence_identifier = sequence_identifier
         self._discard = discard
+        
+        if init_document is not None:
+            # Create sequence from init document, in order to immediately start document output
+            log.info('Creating document sequence from init document {}'.format(
+                init_document
+            ))
+            with open(init_document, 'r') as xml_file:
+                xml_content = xml_file.read()
+            xml_doc = EBUTT3Document.create_from_xml(xml_content)
+            
+            self._sequence = EBUTT3DocumentSequence.create_from_document(xml_doc, verbose=self._verbose)
+            if self._reference_clock is None:
+                self._reference_clock = self._sequence.reference_clock
+        
 
     @property
     def last_segment_end(self):


### PR DESCRIPTION
So far the resequencer starts to regularly issue documents only after
the first EBU-TT Live document has been received. However for some use
cases this might be inconvenient as an active document must exist at all
times e.g. when creating segments for an MPEG-DASH stream. The reason
for documents being issued only after the first received EBU-TT Live
document is that certain parameters of that document are used for
initialisation.

This commit adds a new configuration parameter that specifies a document
which will be used for initialisation (instead of the first received
EBU-TT Live document). Therefore the resequencer will immediately (be
able to) start issuing documents after its creation.

Closes ebu/ebu-tt-live-toolkit#505.