### PR TITLE
Issue 507 timedelta

### DIFF
--- a/ebu_tt_live/bindings/_ebuttdt.py
+++ b/ebu_tt_live/bindings/_ebuttdt.py
@@ -38,13 +38,6 @@ class _TimedeltaBindingMixin(object):
     }
 
     @classmethod
-    def _int_or_none(cls, value):
-        try:
-            return int(value)
-        except TypeError:
-            return 0
-
-    @classmethod
     def compatible_timebases(cls):
         return cls._compatible_timebases
 
@@ -320,10 +313,10 @@ class FullClockTimingType(SemanticValidationMixin, _TimedeltaBindingMixin, ebutt
         :return:
         """
         hours_str, minutes_str, seconds_str, seconds_fraction_str = [x for x in cls._groups_regex.match(instance).groups()]
-        milliseconds = seconds_fraction_str and cls._int_or_none('{:0<3}'.format(seconds_fraction_str)[:3]) or 0
-        return timedelta(hours=cls._int_or_none(hours_str), 
-            minutes=cls._int_or_none(minutes_str), 
-            seconds=cls._int_or_none(seconds_str), 
+        milliseconds = seconds_fraction_str and float('0.' + seconds_fraction_str) * 1000 or 0
+        return timedelta(hours=int(hours_str), 
+            minutes=int(minutes_str), 
+            seconds=int(seconds_str), 
             milliseconds=milliseconds)
 
     @classmethod
@@ -372,10 +365,10 @@ class LimitedClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.limitedClockTim
         :return:
         """
         hours_str, minutes_str, seconds_str, seconds_fraction_str = [x for x in cls._groups_regex.match(instance).groups()]
-        milliseconds = seconds_fraction_str and cls._int_or_none('{:0<3}'.format(seconds_fraction_str)[:3]) or 0
-        return timedelta(hours=cls._int_or_none(hours_str), 
-            minutes=cls._int_or_none(minutes_str), 
-            seconds=cls._int_or_none(seconds_str), 
+        milliseconds = seconds_fraction_str and float('0.' + seconds_fraction_str) * 1000 or 0
+        return timedelta(hours=int(hours_str), 
+            minutes=int(minutes_str), 
+            seconds=int(seconds_str), 
             milliseconds=milliseconds)
         
 

--- a/ebu_tt_live/bindings/_ebuttdt.py
+++ b/ebu_tt_live/bindings/_ebuttdt.py
@@ -319,11 +319,12 @@ class FullClockTimingType(SemanticValidationMixin, _TimedeltaBindingMixin, ebutt
         :param instance:
         :return:
         """
-        hours, minutes, seconds, milliseconds = map(
-            lambda x: cls._int_or_none(x),
-            cls._groups_regex.match(instance).groups()
-        )
-        return timedelta(hours=hours, minutes=minutes, seconds=seconds, milliseconds=milliseconds)
+        hours_str, minutes_str, seconds_str, seconds_fraction_str = [x for x in cls._groups_regex.match(instance).groups()]
+        milliseconds = seconds_fraction_str and cls._int_or_none('{:0<3}'.format(seconds_fraction_str)[:3]) or 0
+        return timedelta(hours=cls._int_or_none(hours_str), 
+            minutes=cls._int_or_none(minutes_str), 
+            seconds=cls._int_or_none(seconds_str), 
+            milliseconds=milliseconds)
 
     @classmethod
     def from_timedelta(cls, instance):
@@ -370,11 +371,13 @@ class LimitedClockTimingType(_TimedeltaBindingMixin, ebuttdt_raw.limitedClockTim
         :param instance:
         :return:
         """
-        hours, minutes, seconds, milliseconds = map(
-            lambda x: cls._int_or_none(x),
-            cls._groups_regex.match(instance).groups()
-        )
-        return timedelta(hours=hours, minutes=minutes, seconds=seconds, milliseconds=milliseconds)
+        hours_str, minutes_str, seconds_str, seconds_fraction_str = [x for x in cls._groups_regex.match(instance).groups()]
+        milliseconds = seconds_fraction_str and cls._int_or_none('{:0<3}'.format(seconds_fraction_str)[:3]) or 0
+        return timedelta(hours=cls._int_or_none(hours_str), 
+            minutes=cls._int_or_none(minutes_str), 
+            seconds=cls._int_or_none(seconds_str), 
+            milliseconds=milliseconds)
+        
 
     @classmethod
     def from_timedelta(cls, instance):

--- a/ebu_tt_live/bindings/test/test_times.py
+++ b/ebu_tt_live/bindings/test/test_times.py
@@ -1,0 +1,72 @@
+
+from unittest import TestCase
+from unittest import skip, SkipTest
+from datetime import timedelta
+from ebu_tt_live.bindings import ebuttdt
+from pyxb import SimpleTypeValueError, SimpleFacetValueError
+
+class TestTimecountTimingType(TestCase):
+
+    _test_cases = {
+        '1.3s': timedelta(seconds = 1, milliseconds = 300),
+        '1.03s': timedelta(seconds = 1, milliseconds = 30),
+        '1.30s': timedelta(seconds = 1, milliseconds = 300),
+        '1s': timedelta(seconds = 1),
+        '1.3m': timedelta(minutes = 1, seconds = 18),
+        '1.03m': timedelta(minutes = 1, seconds = 1, milliseconds = 800),
+        '1.30m': timedelta(minutes = 1, seconds = 18),
+        '1m': timedelta(minutes = 1),
+        '1.3h': timedelta(hours = 1, minutes = 18),
+        '1.03h': timedelta(hours = 1, minutes = 1, seconds = 48),
+        '1.30h': timedelta(hours = 1, minutes = 18),
+        '1h': timedelta(hours = 1),
+        '1.3ms': timedelta(milliseconds = 1, microseconds = 300),
+        '1.03ms': timedelta(milliseconds = 1, microseconds = 30),
+        '1.30ms': timedelta(milliseconds = 1, microseconds = 300),
+        '1ms': timedelta(milliseconds = 1),
+    }
+
+    _type_class = ebuttdt.TimecountTimingType
+
+    def test_as_timedelta(self):
+        for t, td in self._test_cases.items() :
+            test_instance = self._type_class(t)
+            self.assertEqual(test_instance.timedelta, td)
+            assert test_instance == t
+
+
+
+class TestFullClockTimingType(TestCase):
+
+    _test_cases = {
+        '111:22:33': timedelta(hours = 111, minutes = 22, seconds = 33),
+        '111:22:33.4': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 400),
+        '111:22:33.04': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 40),
+        '111:22:33.40': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 400),
+    }
+
+    _type_class = ebuttdt.FullClockTimingType
+
+    def test_as_timedelta(self):
+        for t, td in self._test_cases.items() :
+            test_instance = self._type_class(t)
+            self.assertEqual(test_instance.timedelta, td)
+            assert test_instance == t
+
+
+class TestLimitedClockTimingType(TestCase):
+
+    _test_cases = {
+        '11:22:33': timedelta(hours = 11, minutes = 22, seconds = 33),
+        '11:22:33.4': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
+        '11:22:33.04': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 40),
+        '11:22:33.40': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
+    }
+    
+    _type_class = ebuttdt.LimitedClockTimingType
+
+    def test_as_timedelta(self):
+        for t, td in self._test_cases.items() :
+            test_instance = self._type_class(t)
+            self.assertEqual(test_instance.timedelta, td)
+            assert test_instance == t

--- a/ebu_tt_live/bindings/test/test_times.py
+++ b/ebu_tt_live/bindings/test/test_times.py
@@ -14,6 +14,7 @@ class TestTimecountTimingType(TestCase):
         '1.003s': timedelta(seconds = 1, milliseconds = 3),
         '1.030s': timedelta(seconds = 1, milliseconds = 30),
         '1.300s': timedelta(seconds = 1, milliseconds = 300),
+        '1.3456s': timedelta(seconds = 1, milliseconds = 345.6),
         '1s': timedelta(seconds = 1),
         '1.3m': timedelta(minutes = 1, seconds = 18),
         '1.03m': timedelta(minutes = 1, seconds = 1, milliseconds = 800),
@@ -57,6 +58,7 @@ class TestFullClockTimingType(TestCase):
         '111:22:33.400': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 400),
         '111:22:33.040': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 40),
         '111:22:33.004': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 4),
+        '111:22:33.0045': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 4.5),
     }
 
     _type_class = ebuttdt.FullClockTimingType
@@ -77,7 +79,9 @@ class TestLimitedClockTimingType(TestCase):
         '11:22:33.40': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
         '11:22:33.400': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
         '11:22:33.040': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 40),
-        '11:22:33.004': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 4),    }
+        '11:22:33.004': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 4),
+        '11:22:33.0045': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 4.5),
+    }
     
     _type_class = ebuttdt.LimitedClockTimingType
 

--- a/ebu_tt_live/bindings/test/test_times.py
+++ b/ebu_tt_live/bindings/test/test_times.py
@@ -11,19 +11,30 @@ class TestTimecountTimingType(TestCase):
         '1.3s': timedelta(seconds = 1, milliseconds = 300),
         '1.03s': timedelta(seconds = 1, milliseconds = 30),
         '1.30s': timedelta(seconds = 1, milliseconds = 300),
+        '1.003s': timedelta(seconds = 1, milliseconds = 3),
+        '1.030s': timedelta(seconds = 1, milliseconds = 30),
+        '1.300s': timedelta(seconds = 1, milliseconds = 300),
         '1s': timedelta(seconds = 1),
         '1.3m': timedelta(minutes = 1, seconds = 18),
         '1.03m': timedelta(minutes = 1, seconds = 1, milliseconds = 800),
         '1.30m': timedelta(minutes = 1, seconds = 18),
+        '1.003m': timedelta(minutes = 1, milliseconds = 180),
+        '1.030m': timedelta(minutes = 1, seconds = 1, milliseconds = 800),
+        '1.300m': timedelta(minutes = 1, seconds = 18),
         '1m': timedelta(minutes = 1),
         '1.3h': timedelta(hours = 1, minutes = 18),
         '1.03h': timedelta(hours = 1, minutes = 1, seconds = 48),
         '1.30h': timedelta(hours = 1, minutes = 18),
+        '1.003h': timedelta(hours = 1, seconds=10, milliseconds = 800),
+        '1.030h': timedelta(hours = 1, minutes = 1, seconds = 48),
+        '1.300h': timedelta(hours = 1, minutes = 18),
         '1h': timedelta(hours = 1),
         '1.3ms': timedelta(milliseconds = 1, microseconds = 300),
         '1.03ms': timedelta(milliseconds = 1, microseconds = 30),
         '1.30ms': timedelta(milliseconds = 1, microseconds = 300),
-        '1ms': timedelta(milliseconds = 1),
+        '1.003ms': timedelta(milliseconds = 1, microseconds = 3),
+        '1.030ms': timedelta(milliseconds = 1, microseconds = 30),
+        '1.300ms': timedelta(milliseconds = 1, microseconds = 300),        '1ms': timedelta(milliseconds = 1),
     }
 
     _type_class = ebuttdt.TimecountTimingType
@@ -43,6 +54,9 @@ class TestFullClockTimingType(TestCase):
         '111:22:33.4': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 400),
         '111:22:33.04': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 40),
         '111:22:33.40': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 400),
+        '111:22:33.400': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 400),
+        '111:22:33.040': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 40),
+        '111:22:33.004': timedelta(hours = 111, minutes = 22, seconds = 33, milliseconds = 4),
     }
 
     _type_class = ebuttdt.FullClockTimingType
@@ -61,7 +75,9 @@ class TestLimitedClockTimingType(TestCase):
         '11:22:33.4': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
         '11:22:33.04': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 40),
         '11:22:33.40': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
-    }
+        '11:22:33.400': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 400),
+        '11:22:33.040': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 40),
+        '11:22:33.004': timedelta(hours = 11, minutes = 22, seconds = 33, milliseconds = 4),    }
     
     _type_class = ebuttdt.LimitedClockTimingType
 

--- a/ebu_tt_live/bindings/test/test_times.py
+++ b/ebu_tt_live/bindings/test/test_times.py
@@ -35,7 +35,8 @@ class TestTimecountTimingType(TestCase):
         '1.30ms': timedelta(milliseconds = 1, microseconds = 300),
         '1.003ms': timedelta(milliseconds = 1, microseconds = 3),
         '1.030ms': timedelta(milliseconds = 1, microseconds = 30),
-        '1.300ms': timedelta(milliseconds = 1, microseconds = 300),        '1ms': timedelta(milliseconds = 1),
+        '1.300ms': timedelta(milliseconds = 1, microseconds = 300),
+        '1ms': timedelta(milliseconds = 1),
     }
 
     _type_class = ebuttdt.TimecountTimingType


### PR DESCRIPTION
Fixes #507 by interpreting decimal fractions of seconds as milliseconds, up to 3 decimal places, and adding tests to verify this behaviour.