### PR TITLE
Resequencer: fix sequence number 1 if no content

### DIFF
--- a/ebu_tt_live/documents/ebutt3.py
+++ b/ebu_tt_live/documents/ebutt3.py
@@ -706,7 +706,7 @@ class EBUTT3DocumentSequence(TimelineUtilMixin, CloningDocumentSequence):
             clock_mode=self._reference_clock.clock_mode,
             sequence_identifier=self._sequence_identifier,
             authors_group_identifier=self.authors_group_identifier,
-            sequence_number=self._last_sequence_number,
+            sequence_number=kwargs.get('sequence_number', self._last_sequence_number),
             lang=self._lang
         )
 
@@ -992,15 +992,16 @@ class EBUTT3DocumentSequence(TimelineUtilMixin, CloningDocumentSequence):
                 
             begin = doc_ending
 
+        current_sequence_number = sequence_number is not None and sequence_number or 1
         if not document_segments:
             # TODO: This is good question what now? no documents found for range
-            document = self.create_compatible_document()
+            document = self.create_compatible_document(sequence_number=current_sequence_number)
             # comp_doc.set_begin(begin)
             # comp_doc.set_end(end)
         else:
             splicer = EBUTT3Splicer(
                 sequence_identifier='{}_resegmented'.format(self.sequence_identifier),
-                sequence_number=sequence_number is not None and sequence_number or 1,
+                sequence_number=current_sequence_number,
                 document_segments=document_segments
             )
             document = EBUTT3Document.create_from_raw_binding(splicer.spliced_document)


### PR DESCRIPTION
While the EBUTT3Splicer is provided with the current sequence number
stored/incremented by the Resequencer, the `create_compatible_document`
method so far refers to the sequence number stored internally by
EBUTT3DocumentSequence instead. This leads to a sequence number of 1 in
the issued output document if no subtitle content is available.

To align with the correct (strictly monotonic increasing) sequence
number, always use the one stored by the Resequencer.

Fixes ebu/ebu-tt-live-toolkit#502.