### PR TITLE
Resequencer: allow to immediately issue documents

### DIFF
--- a/docs/source/configurator.rst
+++ b/docs/source/configurator.rst
@@ -99,6 +99,7 @@ Node type dependent options for [nodeN] : ::
    ├─sequence_identifier : sequence identifier, default "re-sequencer"
    ├─segment_length : duration of each output segment in seconds, default 2
    ├─begin_output : ["immediate" (default) | {begin time} ] the time at which the first output segment should begin.
+   ├─init_document : File path to a document used to set initial parameters and afterwards start issuing documents (instead of awaiting the first received document), default None
    ├─discard : whether to discard content that has been encoded, default True
    └─clock
      └─type : ["local" (default) | "auto" | "clock"]

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -67,11 +67,11 @@ consumer is listening. See detailed instructions here:
 Distributor
 -----------
 This script mimics a distribution node. To see it forwarding documents from the
-Simple Producer the the Simple Consumer using Websocket, run ``ebu-run
+Simple Producer the Simple Consumer using Websocket, run ``ebu-run
 --admin.conf=ebu_tt_live/examples/config/sproducer_dist_sconsumer_ws.json``. A
 more interesting scenario is distributing documents from the User Input Producer
 to two consumer nodes: ``ebu-run
---admin.conf=ebu_tt_live/examples/config/user_input_producer_dist_consumers``.
+--admin.conf=ebu_tt_live/examples/config/user_input_producer_dist_consumers.json``.
 
 Like the Simple Producer, the Distributor can also save the documents it
 receives to the file system. To do that, create you own configuration file as
@@ -131,8 +131,14 @@ Note that the resequencer output can contain duplicated ``style`` and ``region``
 elements. These can be cleaned up by passing the output to a DeDuplicator
 node before downstream encoding to other formats.
 
-The resequencer does not begin emitting any documents until it has received
-at least one input document.
+In general the resequencer does not begin emitting any documents until it has received
+at least one input document. To immediately start to emit documents an
+initial document can be configured. Necessary initial parameters like
+language or sequence ID are retrieved from that document.
+
+Note that the resequencer accepts only input documents which all have the
+same sequence ID. This sequence ID is determined by the first received input
+document (or the configured initial document instead, if applicable).
 
 Use ``ebu-run`` to start
 this script, for example ``ebu-run --admin.conf=ebu_tt_live/examples/config/sproducer_resequencer_direct_ebuttd_encoder_fs.json``

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -67,7 +67,7 @@ consumer is listening. See detailed instructions here:
 Distributor
 -----------
 This script mimics a distribution node. To see it forwarding documents from the
-Simple Producer the Simple Consumer using Websocket, run ``ebu-run
+Simple Producer to the Simple Consumer using Websocket, run ``ebu-run
 --admin.conf=ebu_tt_live/examples/config/sproducer_dist_sconsumer_ws.json``. A
 more interesting scenario is distributing documents from the User Input Producer
 to two consumer nodes: ``ebu-run

--- a/ebu_tt_live/config/node.py
+++ b/ebu_tt_live/config/node.py
@@ -102,6 +102,7 @@ class ReSequencer(ProducerMixin, ConsumerMixin, NodeBase):
     required_config.add_option('segment_length', default=2.0)
     required_config.clock = Namespace()
     required_config.clock.add_option('type', default='local', from_string_converter=get_clock)
+    required_config.add_option('init_document', default=None)
     required_config.add_option('discard', default=True)
     required_config.add_option(
         'begin_output',
@@ -128,6 +129,7 @@ class ReSequencer(ProducerMixin, ConsumerMixin, NodeBase):
         self.component = processing_node.ReSequencer(
             node_id=self.config.id,
             reference_clock=self._clock.component,
+            init_document=self.config.init_document,
             discard=self.config.discard,
             segment_length=self.config.segment_length,
             sequence_identifier=self.config.sequence_identifier

--- a/ebu_tt_live/node/consumer.py
+++ b/ebu_tt_live/node/consumer.py
@@ -76,7 +76,7 @@ class ReSequencer(AbstractProducerNode, SimpleConsumer):
     _expects = EBUTT3Document
     _provides = EBUTT3Document
 
-    def __init__(self, node_id, reference_clock, segment_length, discard, sequence_identifier,
+    def __init__(self, node_id, reference_clock, segment_length, init_document, discard, sequence_identifier,
                  consumer_carriage=None, producer_carriage=None, **kwargs):
         super(ReSequencer, self).__init__(
             node_id=node_id,
@@ -91,6 +91,20 @@ class ReSequencer(AbstractProducerNode, SimpleConsumer):
         self._segment_counter = 1
         self._sequence_identifier = sequence_identifier
         self._discard = discard
+        
+        if init_document is not None:
+            # Create sequence from init document, in order to immediately start document output
+            log.info('Creating document sequence from init document {}'.format(
+                init_document
+            ))
+            with open(init_document, 'r') as xml_file:
+                xml_content = xml_file.read()
+            xml_doc = EBUTT3Document.create_from_xml(xml_content)
+            
+            self._sequence = EBUTT3DocumentSequence.create_from_document(xml_doc, verbose=self._verbose)
+            if self._reference_clock is None:
+                self._reference_clock = self._sequence.reference_clock
+        
 
     @property
     def last_segment_end(self):

--- a/ebu_tt_live/node/consumer.py
+++ b/ebu_tt_live/node/consumer.py
@@ -76,8 +76,8 @@ class ReSequencer(AbstractProducerNode, SimpleConsumer):
     _expects = EBUTT3Document
     _provides = EBUTT3Document
 
-    def __init__(self, node_id, reference_clock, segment_length, init_document, discard, sequence_identifier,
-                 consumer_carriage=None, producer_carriage=None, **kwargs):
+    def __init__(self, node_id, reference_clock, segment_length, discard, sequence_identifier,
+                 consumer_carriage=None, producer_carriage=None, init_document=None, **kwargs):
         super(ReSequencer, self).__init__(
             node_id=node_id,
             consumer_carriage=consumer_carriage,

--- a/ebu_tt_live/node/consumer.py
+++ b/ebu_tt_live/node/consumer.py
@@ -35,9 +35,7 @@ class SimpleConsumer(AbstractConsumerNode):
                 log.info('Creating document sequence from first document {}'.format(
                     document
                 ))
-                self._sequence = EBUTT3DocumentSequence.create_from_document(document, verbose=self._verbose)
-                if self._reference_clock is None:
-                    self._reference_clock = self._sequence.reference_clock
+                self.create_sequence_from_document(document)
             if document.availability_time is None:
                 document.availability_time = self._reference_clock.get_time()
 
@@ -55,6 +53,11 @@ class SimpleConsumer(AbstractConsumerNode):
                         document.sequence_number
                     )
                 )
+
+    def create_sequence_from_document(self, document):
+        self._sequence = EBUTT3DocumentSequence.create_from_document(document, verbose=self._verbose)
+        if self._reference_clock is None:
+            self._reference_clock = self._sequence.reference_clock
 
     @property
     def reference_clock(self):
@@ -100,11 +103,7 @@ class ReSequencer(AbstractProducerNode, SimpleConsumer):
             with open(init_document, 'r') as xml_file:
                 xml_content = xml_file.read()
             xml_doc = EBUTT3Document.create_from_xml(xml_content)
-            
-            self._sequence = EBUTT3DocumentSequence.create_from_document(xml_doc, verbose=self._verbose)
-            if self._reference_clock is None:
-                self._reference_clock = self._sequence.reference_clock
-        
+            self.create_sequence_from_document(xml_doc)
 
     @property
     def last_segment_end(self):


### PR DESCRIPTION
So far the resequencer starts to regularly issue documents only after
the first EBU-TT Live document has been received. However for some use
cases this might be inconvenient as an active document must exist at all
times e.g. when creating segments for an MPEG-DASH stream. The reason
for documents being issued only after the first received EBU-TT Live
document is that certain parameters of that document are used for
initialisation.

This commit adds a new configuration parameter that specifies a document
which will be used for initialisation (instead of the first received
EBU-TT Live document). Therefore the resequencer will immediately (be
able to) start issuing documents after its creation.

Closes ebu/ebu-tt-live-toolkit#505.