### PR TITLE
Issue 447 resequencer documentation

### DIFF
--- a/docs/source/deduplication.rst
+++ b/docs/source/deduplication.rst
@@ -13,7 +13,7 @@ After copying ``styling`` and ``layout`` into a ``list()`` and setting them up f
 Because ``style`` and ``region`` elements can have ``style`` attributes, these
 are deduplicated first. At this stage, it's possible that where two identical elements
 that differed only in their style references, these may end up looking the same.
- Each element is then passed through the
+Each element is then passed through the
 :py:class:`ebu_tt_live.node.deduplicator.ComparableElement` class, which processes
 each attribute, omitting the ``xml:id`` and using the
 :py:func:`ebu_tt_live.node.deduplicator.ReplaceNone` function to replace empty

--- a/docs/source/ebu_tt_live.node.rst
+++ b/docs/source/ebu_tt_live.node.rst
@@ -74,7 +74,7 @@ node Package
     :show-inheritance:
 
 :mod:`deduplicator` Module
-----------------------
+--------------------------
 
 .. automodule:: ebu_tt_live.node.deduplicator
     :members:

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -131,6 +131,9 @@ Note that the resequencer output can contain duplicated ``style`` and ``region``
 elements. These can be cleaned up by passing the output to a DeDuplicator
 node before downstream encoding to other formats.
 
+The resequencer does not begin emitting any documents until it has received
+at least one input document.
+
 Use ``ebu-run`` to start
 this script, for example ``ebu-run --admin.conf=ebu_tt_live/examples/config/sproducer_resequencer_direct_ebuttd_encoder_fs.json``
 

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -103,9 +103,36 @@ example ``ebu-run --admin.conf=ebu_tt_live/examples/config/buffer_delay.json``
 DeDuplicator Node
 -----------------
 This node addresses instances where ``style`` and ``region`` elements and
-attributes are duplicated.
+attributes are duplicated, which can occur for example when sequences are
+resequenced.
 For the default configuration of the node, see:
 ``ebu-run --admin.conf=ebu_tt_live/examples/config/deduplicator_fs.json``
+
+Resequencer Node
+----------------
+This node consumes documents from one sequence and
+creates a new sequence of documents based on the content in that input sequence,
+where every document in the output sequence has the same duration. The
+resequencer repeatedly extracts and then outputs a document of the specified
+duration, then waits for a period equal to that 
+duration before extracting the next document. It can be configured to begin
+extracting the first document immediately when it is run, or to wait until a
+specific time until extracting the first document. 
+
+The resequencer is
+particularly useful upstream of an EBU-TT-D Encoder, to generate segmented
+EBU-TT-D, for example prior to wrapping in fragmented MPEG-4 and serving
+with a DASH or HLS manifest; those onward steps are not part of this project.
+This pattern effectively converts an asynchronous stream of input documents
+into something that can be delivered synchronously downstream, which is
+useful for distribution to media players.
+
+Note that the resequencer output can contain duplicated ``style`` and ``region``
+elements. These can be cleaned up by passing the output to a DeDuplicator
+node before downstream encoding to other formats.
+
+Use ``ebu-run`` to start
+this script, for example ``ebu-run --admin.conf=ebu_tt_live/examples/config/sproducer_resequencer_direct_ebuttd_encoder_fs.json``
 
 Retiming Delay Node
 -------------------

--- a/ebu_tt_live/bindings/validation/presentation.py
+++ b/ebu_tt_live/bindings/validation/presentation.py
@@ -43,14 +43,14 @@ class StyledElementMixin(object):
     def _semantic_collect_applicable_styles(self, dataset, style_type, parent_binding, defer_font_size=False,
                                             extra_referenced_styles=None):
         """
-        This function identifies the styling dependdncy chain for the styled element in question.
+        This function identifies the styling dependency chain for the styled element in question.
 
         :param dataset: Semantic dataset
-        :param style_type: the style_type to be used in the process (there are different style types for EBU-TT D and
-        live).
+        :param style_type: the style_type to be used in the process (there are different style types for EBU-TT D and live).
         :param parent_binding: The immediate parent of the styled element in the document structure
         :param defer_font_size: If True then fontsize can stay percentage in case it could not be calculated
         :param extra_referenced_styles: Used by region to inject its extra style attributes
+
         :return:
         """
 


### PR DESCRIPTION
Close #447 by adding basic Resequencer documentation.

In passing, fixes a few documentation build warnings and a typo.