### PR TITLE
Handle timing types in elements without crashing

### DIFF
--- a/ebu_tt_live/bindings/_ebuttdt.py
+++ b/ebu_tt_live/bindings/_ebuttdt.py
@@ -70,20 +70,25 @@ class _TimedeltaBindingMixin(object):
             # This means we are in XML parsing context. There should be a timeBase and a timing_attribute_name in the
             # context object.
             time_base = context['timeBase']
-            timing_att_name = context['timing_attribute_name']
-            if time_base not in cls._compatible_timebases[timing_att_name]:
-                log.debug(ERR_SEMANTIC_VALIDATION_TIMING_TYPE.format(
-                    attr_name=timing_att_name,
-                    attr_type=cls,
-                    attr_value=args,
-                    time_base=time_base
-                ))
-                raise pyxb.SimpleTypeValueError(ERR_SEMANTIC_VALIDATION_TIMING_TYPE.format(
-                    attr_name=timing_att_name,
-                    attr_type=cls,
-                    attr_value=args,
-                    time_base=time_base
-                ))
+            # It is possible for a timing type to exist as the value of an element not an attribute,
+            # in which case no timing_attribute_name is in the context; in that case don't attempt
+            # to validate the data against a timebase. At the moment this only affects the
+            # documentStartOfProgramme metadata element.
+            if 'timing_attribute_name' in context:
+                timing_att_name = context['timing_attribute_name']
+                if time_base not in cls._compatible_timebases[timing_att_name]:
+                    log.debug(ERR_SEMANTIC_VALIDATION_TIMING_TYPE.format(
+                        attr_name=timing_att_name,
+                        attr_type=cls,
+                        attr_value=args,
+                        time_base=time_base
+                    ))
+                    raise pyxb.SimpleTypeValueError(ERR_SEMANTIC_VALIDATION_TIMING_TYPE.format(
+                        attr_name=timing_att_name,
+                        attr_type=cls,
+                        attr_value=args,
+                        time_base=time_base
+                    ))
         for item in args:
             if isinstance(item, timedelta):
                 result.append(cls.from_timedelta(item))

--- a/ebu_tt_live/xsd/ebutt_datatypes.xsd
+++ b/ebu_tt_live/xsd/ebutt_datatypes.xsd
@@ -150,6 +150,10 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			<xs:pattern value="([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]:[0-9][0-9]"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="startOfProgrammeTimingType">
+		<xs:union
+			memberTypes="ebuttdt:clockTimingType ebuttdt:smpteTimingType"/>
+	</xs:simpleType>
 	<xs:simpleType name="clockTimingType">
 		<xs:union memberTypes="ebuttdt:limitedClockTimingType ebuttdt:timecountTimingType"/>
 	</xs:simpleType>

--- a/ebu_tt_live/xsd/ebutt_metadata.xsd
+++ b/ebu_tt_live/xsd/ebutt_metadata.xsd
@@ -342,7 +342,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 							text row (MNC). </xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="documentStartOfProgramme" type="ebuttdt:smpteTimingType" minOccurs="0">
+				<xs:element name="documentStartOfProgramme" type="ebuttdt:startOfProgrammeTimingType" minOccurs="0">
 					<xs:annotation>
 						<xs:documentation>The time code of the first frame of the recorded video
 							signal which is intended for transmission. Note: When the referenced

--- a/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
+++ b/testing/bdd/features/validation/timeBase_timeformat_constraints.feature
@@ -194,3 +194,29 @@ Feature: ttp:timeBase-related attribute constraints
     | timeBase_timeformat.xml | smpte     | 11.11:11     |           |
     | timeBase_timeformat.xml | smpte     | 11.11        |           |
     | timeBase_timeformat.xml | smpte     | 11:11:11:111 |           |
+
+Scenario: Times in documentStartOfProgramme do not cause processing or validation error
+  Given an xml file <xml_file>
+  When it has timeBase <time_base>
+  And it has documentStartOfProgramme <start_time>
+  Then document is valid
+
+  Examples:
+  | xml_file                        | time_base  | start_time   |
+  | timeBase_timeformat.xml         | media      | 00:00:00.000 |
+  | timeBase_timeformat.xml         | clock      | 00:00:00.000 |
+  | timeBase_timeformat.xml         | smpte      | 10:00:00:00  |
+
+# Element based time validation is not yet implemented
+@skip
+Scenario: Times in documentStartOfProgramme do cause validation error
+  Given an xml file <xml_file>
+  When it has timeBase <time_base>
+  And it has documentStartOfProgramme <start_time>
+  Then document is invalid
+
+  Examples:
+  | xml_file                        | time_base  | start_time   |
+  | timeBase_timeformat.xml         | media      | 00:00:00:00  |
+  | timeBase_timeformat.xml         | clock      | 00:00:60     |
+  | timeBase_timeformat.xml         | smpte      | 10:00:00.00  |

--- a/testing/bdd/templates/timeBase_timeformat.xml
+++ b/testing/bdd/templates/timeBase_timeformat.xml
@@ -23,7 +23,11 @@
         xmlns:xml="http://www.w3.org/XML/1998/namespace">
   <tt:head>
     <tt:metadata>
-      <ebuttm:documentMetadata/>
+      <ebuttm:documentMetadata>
+      {% if start_of_programme %}
+        <ebuttm:documentStartOfProgramme>{{ start_of_programme }}</ebuttm:documentStartOfProgramme>
+       {% endif %}
+      </ebuttm:documentMetadata>
     </tt:metadata>
     <tt:styling>
       <tt:style xml:id="ID001"/>

--- a/testing/bdd/test_timeBase_timeformat.py
+++ b/testing/bdd/test_timeBase_timeformat.py
@@ -51,3 +51,8 @@ def when_span_begin(span_begin, template_dict):
 @when('it has span end time <span_end>')
 def when_span_end(span_end, template_dict):
     template_dict['span_end'] = span_end
+
+@when('it has documentStartOfProgramme <start_time>')
+def when_documentStartOfProgramme(start_time, template_dict):
+    template_dict['start_of_programme'] = start_time
+    


### PR DESCRIPTION
Fixes #492

* Define the type of `ebuttm:documentStartOfProgramme` correctly.
* When processing a timing type outside of the context of an attribute, bypass the timebase validation.

This is possibly a temporary hack, since element timing validation might be needed one day, but since we don't do anything with metadata elements, this isn't a disaster (yet).