### PR TITLE
Fix minor Sphinx build warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,7 +173,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/source/deduplication.rst
+++ b/docs/source/deduplication.rst
@@ -13,7 +13,7 @@ After copying ``styling`` and ``layout`` into a ``list()`` and setting them up f
 Because ``style`` and ``region`` elements can have ``style`` attributes, these
 are deduplicated first. At this stage, it's possible that where two identical elements
 that differed only in their style references, these may end up looking the same.
- Each element is then passed through the
+Each element is then passed through the
 :py:class:`ebu_tt_live.node.deduplicator.ComparableElement` class, which processes
 each attribute, omitting the ``xml:id`` and using the
 :py:func:`ebu_tt_live.node.deduplicator.ReplaceNone` function to replace empty

--- a/docs/source/ebu_tt_live.node.rst
+++ b/docs/source/ebu_tt_live.node.rst
@@ -74,7 +74,7 @@ node Package
     :show-inheritance:
 
 :mod:`deduplicator` Module
-----------------------
+--------------------------
 
 .. automodule:: ebu_tt_live.node.deduplicator
     :members:

--- a/docs/source/scripts_and_their_functions.rst
+++ b/docs/source/scripts_and_their_functions.rst
@@ -23,7 +23,7 @@ into a sequence of EBU-TT Live documents using natural language processing. Use
 The default carriage mechanism is WebSocket, so you will need to listen to
 ``ws://127.0.0.1:9000``. Conveniently, we've created an HTML page that does just
 that. After you launch the Simple Producer, open `docs/build/ui/test/index.html <../ui/test/index.html>`_
-or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/test/>`_ in your
+or the `current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/test/>`__ in your
 browser. The 'Broadcast message' field should be populated with the correct
 address (``ws://localhost:9000``). Click 'Connect' and then 'Subscribe'. You can
 also change the identifier for the sequence. The documents should appear in the
@@ -58,7 +58,7 @@ activated and the code built, start one, with a command line such as  ``ebu-run
 --admin.conf ebu_tt_live/examples/config/user_input_producer_consumer.json`` -
 this one runs a simple consumer. Then, in your browser, open
 `docs/build/ui/user_input_producer/index.html <../ui/user_input_producer/index.html>`_ or the
-`current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`_ and click
+`current release pre-built page <http://ebu.github.io/ebu-tt-live-toolkit/ui/user_input_producer/>`__ and click
 'Connect'. Select the sending mode (manual, scheduled or asynchronous). You
 should see the documents arriving in the command line window where the simple
 consumer is listening. See detailed instructions here:

--- a/ebu_tt_live/bindings/validation/presentation.py
+++ b/ebu_tt_live/bindings/validation/presentation.py
@@ -47,7 +47,7 @@ class StyledElementMixin(object):
 
         :param dataset: Semantic dataset
         :param style_type: the style_type to be used in the process (there are different style types for EBU-TT D and
-        live).
+          live).
         :param parent_binding: The immediate parent of the styled element in the document structure
         :param defer_font_size: If True then fontsize can stay percentage in case it could not be calculated
         :param extra_referenced_styles: Used by region to inject its extra style attributes


### PR DESCRIPTION
- adds/removes indent, where necessary
- disables unused HTML static path
- fix title underline
- make links anonymous to prevent name collision

Fixes #530.