### PR TITLE
Fix nltk dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ sphinx-autobuild
 sphinxcontrib-plantuml
 recommonmark
 sphinx-rtd-theme
-pytest-bdd
+pytest-bdd<3.3.0
 pytest-cov
 pytest-mock
 pytest-twisted

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "service_identity",
         "twisted",
         "autobahn<18",
-        "nltk",
+        "nltk<3.5",
         "sortedcontainers",
         "configman",
         "six",


### PR DESCRIPTION
Use the last version that supports Python 2.7.

Fixes #533.